### PR TITLE
Add OpenAPI spec generation for FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,18 @@ npm run setup
 ```bash
 npm test
 uv run --python .venv/bin/python pytest backend/tests
+npm run openapi:generate
 npm run lint
 npm run build
 ```
+
+OpenAPI spec をファイル出力したい場合は、以下でも生成できます。
+
+```bash
+npm run openapi:generate
+```
+
+生成先は `backend/openapi.json` です。実行中のサーバーがある場合は、`http://localhost:8000/openapi.json` でも同じ schema を取得できます。
 
 ## ディレクトリ構成
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,296 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Typing App API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/problems": {
+      "get": {
+        "summary": "Get Problems",
+        "operationId": "get_problems_problems_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/study-results": {
+      "post": {
+        "summary": "Create Study Result",
+        "operationId": "create_study_result_study_results_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StudyResult"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudyResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/study-results/latest": {
+      "get": {
+        "summary": "Fetch Latest Study Result",
+        "operationId": "fetch_latest_study_result_study_results_latest_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudyResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/study-results/summary/today": {
+      "get": {
+        "summary": "Fetch Today Study Summary",
+        "operationId": "fetch_today_study_summary_study_results_summary_today_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyStudySummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DailyStudySummary": {
+        "properties": {
+          "date": {
+            "type": "string",
+            "title": "Date"
+          },
+          "sessions": {
+            "type": "integer",
+            "title": "Sessions"
+          },
+          "solvedProblems": {
+            "type": "integer",
+            "title": "Solvedproblems"
+          }
+        },
+        "type": "object",
+        "required": [
+          "date",
+          "sessions",
+          "solvedProblems"
+        ],
+        "title": "DailyStudySummary"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Problem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "word",
+              "sentence"
+            ],
+            "title": "Type"
+          },
+          "english": {
+            "type": "string",
+            "title": "English"
+          },
+          "japanese": {
+            "type": "string",
+            "title": "Japanese"
+          },
+          "level": {
+            "type": "integer",
+            "title": "Level"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "english",
+          "japanese",
+          "level"
+        ],
+        "title": "Problem"
+      },
+      "ProblemListResponse": {
+        "properties": {
+          "problems": {
+            "items": {
+              "$ref": "#/components/schemas/Problem"
+            },
+            "type": "array",
+            "title": "Problems"
+          }
+        },
+        "type": "object",
+        "required": [
+          "problems"
+        ],
+        "title": "ProblemListResponse"
+      },
+      "StudyResult": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "learn",
+              "review"
+            ],
+            "title": "Mode"
+          },
+          "total_questions": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Total Questions"
+          },
+          "correct_rate": {
+            "type": "integer",
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Correct Rate"
+          },
+          "mistakes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Mistakes"
+          },
+          "average_time": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Average Time"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode",
+          "total_questions",
+          "correct_rate",
+          "mistakes",
+          "average_time",
+          "created_at"
+        ],
+        "title": "StudyResult"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/backend/openapi.py
+++ b/backend/openapi.py
@@ -1,0 +1,42 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from backend.main import create_app
+
+
+def build_openapi_schema() -> dict[str, Any]:
+    app = create_app()  # 既存の FastAPI 定義を再利用して schema を組み立てる
+    return app.openapi()
+
+
+def write_openapi_schema(output_path: str | Path) -> Path:
+    path = Path(output_path)
+    schema = build_openapi_schema()
+
+    path.parent.mkdir(parents=True, exist_ok=True)  # 出力先ディレクトリがなければ先に作成する
+    path.write_text(
+        json.dumps(schema, ensure_ascii=False, indent=2) + "\n",  # 読みやすい整形 JSON で保存する
+        encoding="utf-8",
+    )
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="FastAPI の OpenAPI spec を JSON として出力します。")
+    parser.add_argument(
+        "--output",
+        default="backend/openapi.json",
+        help="出力先の JSON ファイルパス",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    write_openapi_schema(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -1,0 +1,22 @@
+import json
+
+from backend.openapi import build_openapi_schema, write_openapi_schema
+
+
+def test_build_openapi_schema_includes_core_metadata() -> None:
+    schema = build_openapi_schema()
+
+    assert schema["openapi"].startswith("3.")  # OpenAPI 3 系で出力されることを確認する
+    assert schema["info"]["title"] == "Typing App API"  # 既存 API タイトルが spec に反映されることを確認する
+    assert "/problems" in schema["paths"]  # 主要エンドポイントが spec に含まれることを確認する
+    assert "/study-results" in schema["paths"]  # POST エンドポイントも含まれることを確認する
+
+
+def test_write_openapi_schema_persists_json_file(tmp_path) -> None:
+    output_path = tmp_path / "openapi.json"
+
+    write_openapi_schema(output_path)
+
+    saved_schema = json.loads(output_path.read_text())  # 保存した JSON を読み直して整合性を確認する
+    assert saved_schema["info"]["title"] == "Typing App API"  # 保存内容にも同じ metadata が入ることを確認する
+    assert "/study-results/latest" in saved_schema["paths"]  # 既存の GET エンドポイントが保存対象に含まれることを確認する

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "setup": "npm ci && uv venv .venv --allow-existing && uv pip install --python .venv/bin/python -r backend/requirements.txt",
     "dev": "docker compose up --build",
     "dev:down": "docker compose down",
+    "openapi:generate": "uv run --python .venv/bin/python python -m backend.openapi --output backend/openapi.json",
     "dev:frontend:docker": "next dev ./frontend --hostname 0.0.0.0 --port 3000",
     "build": "next build ./frontend",
     "start": "next start ./frontend",


### PR DESCRIPTION
## Summary
- add a backend script to generate the FastAPI OpenAPI schema into `backend/openapi.json`
- add backend tests to verify schema generation and persisted JSON output
- document the generation command in README and expose it via `npm run openapi:generate`

## Testing
- uv run --python .venv/bin/python pytest backend/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API specification is now available in OpenAPI format, documenting all endpoints and data schemas.

* **Documentation**
  * Added instructions for generating and accessing the API specification independently.

* **Tests**
  * Added test coverage for API specification generation and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->