### PR TITLE
docs: simplify AGENTS structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## 基本方針
 
 - すべての出力は日本語で行い、返答は「結論 → 理由 → 次ステップ」の順で構成する。
+- 配下に別の `AGENTS.md` がある場合は、より近い階層の指示を優先する。
 - 変更は最小単位にとどめ、依頼範囲外の修正や既存のユーザー変更の巻き戻しは行わない。
 - コード例を提示する場合は、インラインコメントを入れる。
 
@@ -11,32 +12,16 @@
 - 実装前に、目的、変更範囲、責務分割、テスト方針を含む設計を必ず整理する。
 - 新規実装やバグ修正は、原則として失敗するテストを先に書き、`Red → Green → Refactor` の順で進める。
 - リファクタリング前は関連テストが成功していることを確認し、変更後は影響範囲に応じてテスト・lint・build を実行する。
-- 並列化できる作業は分担してよいが、担当ファイルを明確に分け、最終担当が矛盾を解消してから反映する。
 
 ## 設計方針
 
 - 設計は DDD とクリーンアーキテクチャを基本方針とし、UI やフレームワーク都合ではなく業務ルールを中心に責務を分ける。
-- 依存方向は `domain -> application <- infrastructure/presentation` ではなく、実装上は `presentation -> application -> domain` とし、`infrastructure` は `domain` または `application` の境界を実装する外側の層として扱う。
-- `domain` にはエンティティ、値オブジェクト、ドメインサービス、repository interface だけを置き、`FastAPI`、`Next.js`、`SQLModel`、`localStorage` などの技術詳細を持ち込まない。
-- `application` にはユースケース、コマンド、クエリ、DTO を置き、1 ユースケース 1 責務を原則とする。
-- `presentation` にはルーター、ページ、コンポーネント、schema、view model だけを置き、業務判断や永続化判断を直接書かない。
-- `infrastructure` には DB 実装、API クライアント、ストレージ実装、外部サービス連携を置き、`domain` / `application` で定義した境界を実装する。
-- 既存規模では過剰設計を避け、Aggregate、Domain Event、Factory などは必要性が明確な場合のみ導入する。
-- 既存コードを移行する際は、まずユースケース単位で境界を切り出し、公開 API や画面挙動を維持したまま内部構造だけを段階的に置き換える。
-- フロントエンドは `feature-first` を基本とし、`app` は Next.js のルーティング入口、実装本体は `features/*` に集約する。
-- フロントエンドの各 feature には必要に応じて `ui`、`hooks`、`application`、`api`、`storage`、`model`、`typing` を置き、画面単位で責務を閉じ込める。
-- フロントエンドの `shared` には複数 feature で再利用が明確なものだけを置き、共通型は `shared/types`、共有 API DTO は `shared/api` に置く。
-- フロントエンドでは `components` や `ui` から直接 API / storage / 業務ロジックを抱え込ませず、必要に応じて feature 内の `application`、`hooks`、`model` に分離する。
-- 命名は業務用語を優先し、`manager` や `util` のような曖昧な名前へ逃がさず、`QuestionRepository`、`RecordStudyResultUseCase` のように役割が分かる名前にする。
-- オブジェクト指向を基本とし、データと振る舞いを不必要に分離せず、責務ごとに関心を閉じ込め、カプセル化と明確な公開 `interface` を通じて変更容易性を保つ。継承よりも合成を優先し、状態を書き換える手続きの集積ではなく、役割を持つオブジェクト同士の協調で業務を表現する。
+- 依存方向は `presentation -> application -> domain` を基本とし、`infrastructure` は外側の実装として扱う。
+- `domain` / `application` / `presentation` / `infrastructure` の責務を混在させず、技術詳細を `domain` に持ち込まない。
+- オブジェクト指向を基本とし、責務を持つオブジェクトに振る舞いを閉じ込め、継承より合成を優先する。
+- 命名は業務用語を優先し、`manager` や `util` のような曖昧な名前へ逃がさない。
 
 ## ブランチ運用
 
-- 作業ブランチは `main` から作成し、1つの目的に対して1ブランチを原則とする。
-- ブランチ名は `codex/<種別>/<短い要約>` を基本とし、直接 `main` にコミットしない。
-- `main` は最新取り込み用の保護ブランチとして扱い、実装・修正・コミット作業は必ず作業ブランチ上で行う。
-- 作業開始時は `git branch --show-current` で現在ブランチを確認し、`main` だった場合は作業前に `git switch -c codex/<種別>/<短い要約>` で新規ブランチを切る。
-- 誤って `main` 上で変更を始めた場合も、変更を保持したまま `git switch -c codex/<種別>/<短い要約>` で退避し、そのブランチでコミットを続ける。
-- コミット直前にも `git branch --show-current` を再確認し、`main` が表示された場合はそのままコミットしない。
-- ブランチ作成からコミット、PR 作成まで求められた場合は `git-branch-pr` skill を使用し、ローカル修正だけで終えない。
-- マージ前に、設計更新、関連テスト成功、不要差分がないことを確認する。
+- `main` へ直接コミットせず、`codex/<種別>/<短い要約>` 形式の作業ブランチで作業する。
+- 作業開始時とコミット前に `git branch --show-current` を確認する。

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,17 @@
+# backend/AGENTS.md
+
+## 基本方針
+
+- ルートの `AGENTS.md` を前提に、ここではバックエンド固有の判断だけを補足する。
+- FastAPI や SQLModel の都合より、ユースケースとドメインルールを優先する。
+
+## 設計方針
+
+- `presentation` は HTTP 入出力、schema、レスポンス整形に限定し、業務判断は `application` へ委譲する。
+- `application` はユースケース単位で責務を閉じ、トランザクション境界や repository 呼び出しの調停を担う。
+- `domain` にはエンティティ、値オブジェクト、ドメインサービス、repository interface だけを置き、FastAPI、SQLModel、DB モデルを持ち込まない。
+- `infrastructure` は永続化や外部連携の実装に限定し、`domain` / `application` で定義した境界を実装する。
+
+## テストと確認
+
+- バックエンド変更時は少なくとも `pytest` を実行し、API 契約や OpenAPI に影響する変更では関連テストを追加で確認する。

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,17 @@
+# frontend/AGENTS.md
+
+## 基本方針
+
+- ルートの `AGENTS.md` を前提に、ここではフロントエンド固有の判断だけを補足する。
+- ルーティング入口は `src/app`、実装本体は `src/features/*` に置く。
+- `src/shared` には再利用が明確なものだけを置く。
+
+## 設計方針
+
+- UI コンポーネントは表示責務に寄せ、業務判断、永続化判断、API 呼び出しを直接持ち込まない。
+- 状態遷移やユースケースは feature 内の `application` / `hooks`、API は `api`、保存処理は `storage` に分ける。
+- 曖昧な `utils` や巨大な hooks を避け、責務を feature 内で閉じる。
+
+## テストと確認
+
+- フロントエンド変更時は少なくとも `npm run test` を基準にし、必要に応じて `npm run lint` と `npm run build` まで実行する。


### PR DESCRIPTION
## What changed
- simplified the root `AGENTS.md` to keep only shared rules
- added `frontend/AGENTS.md` and `backend/AGENTS.md` for local guidance
- kept the object-oriented guidance while reducing duplication across files

## Why
- make the instructions easier to scan and maintain
- keep shared rules at the repo root and local rules near the relevant code

## Validation
- reviewed the final diffs for `AGENTS.md`, `frontend/AGENTS.md`, and `backend/AGENTS.md`
- no automated tests run because this change only updates documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined core development principles while establishing detailed backend and frontend-specific architectural guidelines to support consistent implementation practices across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->