### PR TITLE
Fix compose settings for worktree parallel development

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,42 @@ DB ボリュームも削除する場合:
 docker compose down -v
 ```
 
+### `git worktree` で並列開発する場合
+
+`.env` は必須ではありません。単一 worktree の既定値はそのまま `3000` / `8000` を使います。
+
+既定の worktree を起動する場合:
+
+```bash
+docker compose -p typing-app-a up --build
+```
+
+- フロントエンド: `http://localhost:3000`
+- バックエンド: `http://localhost:8000`
+
+2 本目の worktree を別ポートで起動する場合:
+
+```bash
+FRONTEND_PORT=3001 BACKEND_PORT=8001 NEXT_PUBLIC_API_BASE_URL=http://localhost:8001 BACKEND_CORS_ORIGINS=http://localhost:3001 docker compose -p typing-app-b up --build
+```
+
+- フロントエンド: `http://localhost:3001`
+- バックエンド: `http://localhost:8001`
+
+停止する場合:
+
+```bash
+docker compose -p typing-app-a down
+FRONTEND_PORT=3001 BACKEND_PORT=8001 NEXT_PUBLIC_API_BASE_URL=http://localhost:8001 BACKEND_CORS_ORIGINS=http://localhost:3001 docker compose -p typing-app-b down
+```
+
+利用できる環境変数:
+
+- `FRONTEND_PORT`: ホスト側のフロントエンド公開ポート。既定値は `3000`
+- `BACKEND_PORT`: ホスト側のバックエンド公開ポート。既定値は `8000`
+- `NEXT_PUBLIC_API_BASE_URL`: フロントエンドが参照する API の URL。未指定時は `http://localhost:${BACKEND_PORT}` を使う
+- `BACKEND_CORS_ORIGINS`: バックエンドが許可する origin。カンマ区切りで複数指定でき、未指定時は `http://localhost:${FRONTEND_PORT}` を使う
+
 ## よく使うコマンド
 
 ```bash

--- a/backend/presentation/api.py
+++ b/backend/presentation/api.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import NoReturn
@@ -39,6 +40,8 @@ from backend.presentation.schemas import (
     StudyResultRequest,
 )
 
+DEFAULT_CORS_ORIGIN = "http://localhost:3000"
+
 
 def _parse_csv_query(value: str | None) -> list[str] | None:
     if value is None:
@@ -46,6 +49,12 @@ def _parse_csv_query(value: str | None) -> list[str] | None:
 
     parsed_values = [item.strip() for item in value.split(",") if item.strip()]
     return parsed_values if parsed_values else None  # 空配列ならフィルタなし扱いにする
+
+
+def _resolve_cors_origins(value: str | None = None) -> list[str]:
+    configured_value = value if value is not None else os.getenv("BACKEND_CORS_ORIGINS")
+    parsed_origins = _parse_csv_query(configured_value)
+    return parsed_origins or [DEFAULT_CORS_ORIGIN]  # 空文字や未指定時は既定の localhost を許可する
 
 
 def _handle_invalid_master_code(error: ValueError) -> NoReturn:
@@ -66,7 +75,7 @@ def create_app(database_url: str | None = None) -> FastAPI:
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:3000"],
+        allow_origins=_resolve_cors_origins(),
         allow_credentials=True,
         allow_methods=["GET", "POST", "PATCH", "DELETE"],
         allow_headers=["*"],

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -24,6 +24,49 @@ def test_health_returns_ok(client: TestClient) -> None:
     assert response.json() == {"status": "ok"}
 
 
+def test_create_app_allows_default_cors_origin_when_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BACKEND_CORS_ORIGINS", raising=False)  # 既定値フォールバック動作を見るため環境変数を外す
+
+    app = create_app("sqlite://")  # DB 初期化は不要なのでメモリ URL でアプリ定義だけ組み立てる
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
+
+
+def test_create_app_allows_single_cors_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "http://localhost:3001")  # 単一 origin 指定を再現する
+
+    app = create_app("sqlite://")  # 起動前の middleware 設定だけを確認する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001"]
+
+
+def test_create_app_allows_multiple_cors_origins_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "BACKEND_CORS_ORIGINS",
+        "http://localhost:3001, http://localhost:3002 ,",  # 空要素や前後空白を含む入力を正規化対象として与える
+    )
+
+    app = create_app("sqlite://")  # 設定解決結果だけを検証する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001", "http://localhost:3002"]
+
+
+def test_create_app_falls_back_to_default_cors_origin_when_env_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "  ,  ")  # 実質空文字の設定でも既定値へ戻す
+
+    app = create_app("sqlite://")  # 空入力時のフォールバックだけを確認する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
+
+
 def test_quizzes_returns_expected_shape(client: TestClient) -> None:
     response = client.get("/quizzes")
 

--- a/compose.yml
+++ b/compose.yml
@@ -3,16 +3,19 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile.dev
-    command: npm run dev
+    command: >-
+      /bin/sh -c 'export NEXT_PUBLIC_API_BASE_URL="$${NEXT_PUBLIC_API_BASE_URL:-http://localhost:$${BACKEND_PORT:-8000}}";
+      npm run dev'
     working_dir: /app/frontend
     depends_on:
       backend:
         condition: service_healthy
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+      BACKEND_PORT: ${BACKEND_PORT:-8000}
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-}
       WATCHPACK_POLLING: "true"
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:3000"
     volumes:
       - ./frontend:/app/frontend
       - /app/frontend/node_modules
@@ -21,9 +24,13 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile.dev
-    command: uv run --project backend uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000 --app-dir /app
+    command: >-
+      /bin/sh -c 'export BACKEND_CORS_ORIGINS="$${BACKEND_CORS_ORIGINS:-http://localhost:$${FRONTEND_PORT:-3000}}";
+      uv run --project backend uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000 --app-dir /app'
     environment:
+      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:-}
       DATABASE_URL: sqlite:////data/app.db
+      FRONTEND_PORT: ${FRONTEND_PORT:-3000}
       WATCHFILES_FORCE_POLLING: "true"
     healthcheck:
       test:
@@ -36,7 +43,7 @@ services:
       retries: 12
       start_period: 5s
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT:-8000}:8000"
     volumes:
       - ./backend:/app/backend
       - sqlite_data:/data


### PR DESCRIPTION
## What
- make `compose.yml` ports configurable with `FRONTEND_PORT` and `BACKEND_PORT`
- derive `NEXT_PUBLIC_API_BASE_URL` and backend CORS origins from env vars so each worktree can target its own backend
- add backend tests for default, single, multiple, and blank CORS origin resolution
- document `.env`-less `git worktree` parallel startup commands in README

## Why
- current `docker compose` settings assume fixed `3000` / `8000` host ports, so multiple worktrees cannot run in parallel
- backend CORS was fixed to `http://localhost:3000`, which blocks alternate frontend ports

## Validation
- `uv run --project backend pytest backend/tests/test_main.py`
- `npm test`
- `docker compose config`
- `FRONTEND_PORT=3001 BACKEND_PORT=8001 NEXT_PUBLIC_API_BASE_URL=http://localhost:8001 BACKEND_CORS_ORIGINS=http://localhost:3001 docker compose -p typing-app-b config`
- runtime check: launched `typing-app-b` on `3001/8001`, confirmed backend `/health`, confirmed `Access-Control-Allow-Origin: http://localhost:3001`, and confirmed frontend container could reach `http://backend:8000/health`
- note: `typing-app-a` frontend bind on `3000` could not be rechecked because another local `node` process was already listening on port `3000` during verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CORS origins are now configurable via environment variables with sensible localhost defaults
  * Frontend and backend ports are now customizable for flexible deployment configurations

* **Documentation**
  * Added setup guide for running multiple app instances in parallel with custom port and API URL configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->