### PR TITLE
refactor: split backend main tests by responsibility

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,20 @@
 from pathlib import Path
 import sys
 
+import pytest
+from fastapi.testclient import TestClient
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.main import create_app
+
+
+@pytest.fixture
+def client(tmp_path) -> TestClient:
+    database_url = f"sqlite:///{tmp_path / 'test.db'}"
+
+    with TestClient(create_app(database_url)) as test_client:
+        yield test_client

--- a/backend/tests/test_app_bootstrap.py
+++ b/backend/tests/test_app_bootstrap.py
@@ -1,0 +1,139 @@
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+from backend.main import create_app
+from backend.infrastructure.sqlmodel import models  # noqa: F401  # 旧 create_all スキーマを再現するため import する
+
+
+def test_health_returns_ok(client) -> None:
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_create_app_allows_default_cors_origin_when_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BACKEND_CORS_ORIGINS", raising=False)  # 既定値フォールバック動作を見るため環境変数を外す
+
+    app = create_app("sqlite://")  # DB 初期化は不要なのでメモリ URL でアプリ定義だけ組み立てる
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
+
+
+def test_create_app_allows_single_cors_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "http://localhost:3001")  # 単一 origin 指定を再現する
+
+    app = create_app("sqlite://")  # 起動前の middleware 設定だけを確認する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001"]
+
+
+def test_create_app_allows_multiple_cors_origins_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "BACKEND_CORS_ORIGINS",
+        "http://localhost:3001, http://localhost:3002 ,",  # 空要素や前後空白を含む入力を正規化対象として与える
+    )
+
+    app = create_app("sqlite://")  # 設定解決結果だけを検証する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001", "http://localhost:3002"]
+
+
+def test_create_app_falls_back_to_default_cors_origin_when_env_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "  ,  ")  # 実質空文字の設定でも既定値へ戻す
+
+    app = create_app("sqlite://")  # 空入力時のフォールバックだけを確認する
+
+    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
+
+    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
+
+
+def test_create_app_migrates_legacy_words_into_questions(tmp_path) -> None:
+    database_path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        """
+        CREATE TABLE words (
+            id INTEGER PRIMARY KEY,
+            english TEXT NOT NULL,
+            japanese TEXT NOT NULL,
+            level INTEGER NOT NULL,
+            is_active BOOLEAN NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO words (id, english, japanese, level, is_active)
+        VALUES (1, 'legacy-word', '旧データ', 2, 1)
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    database_url = f"sqlite:///{database_path}"
+
+    with TestClient(create_app(database_url)) as migrated_client:
+        response = migrated_client.get("/quizzes?question_types=word")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert any(
+        quiz["english"] == "legacy-word" and quiz["eikenLevel"] == "4"
+        for quiz in body["quizzes"]
+    )
+
+
+def test_create_app_applies_alembic_migrations(tmp_path) -> None:
+    database_path = tmp_path / "migrated.db"
+    database_url = f"sqlite:///{database_path}"
+
+    with TestClient(create_app(database_url)):
+        pass  # アプリ起動時の lifespan で migration 実行だけを確認する
+
+    connection = sqlite3.connect(database_path)
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"  # 作成済みテーブル一覧を取得する
+        ).fetchall()
+    }
+    connection.close()
+
+    assert {
+        "alembic_version",
+        "eiken_levels",
+        "question_types",
+        "typing_questions",
+        "study_results",
+    } <= tables
+
+
+def test_create_app_stamps_existing_schema_without_recreating_tables(tmp_path) -> None:
+    database_path = tmp_path / "existing.db"
+    database_url = f"sqlite:///{database_path}"
+    SQLModel.metadata.create_all(create_engine(database_url))  # 旧実装の create_all だけ済んだ DB を再現する
+
+    with TestClient(create_app(database_url)):
+        pass  # Alembic 導入後も既存 DB で起動できることを確認する
+
+    connection = sqlite3.connect(database_path)
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"  # テーブル一覧から stamp 結果を検証する
+        ).fetchall()
+    }
+    connection.close()
+
+    assert "alembic_version" in tables

--- a/backend/tests/test_questions_quizzes_api.py
+++ b/backend/tests/test_questions_quizzes_api.py
@@ -1,74 +1,7 @@
-import sqlite3
-from datetime import datetime, timezone
-
-import pytest
-from fastapi.testclient import TestClient
-from sqlmodel import SQLModel, create_engine
-
-from backend.main import create_app
-from backend.infrastructure.sqlmodel import models  # noqa: F401  # 旧 create_all スキーマを再現するため import する
 from backend.presentation.api import _parse_csv_query
 
 
-@pytest.fixture
-def client(tmp_path) -> TestClient:
-    database_url = f"sqlite:///{tmp_path / 'test.db'}"
-
-    with TestClient(create_app(database_url)) as test_client:
-        yield test_client
-
-
-def test_health_returns_ok(client: TestClient) -> None:
-    response = client.get("/health")
-
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
-
-
-def test_create_app_allows_default_cors_origin_when_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("BACKEND_CORS_ORIGINS", raising=False)  # 既定値フォールバック動作を見るため環境変数を外す
-
-    app = create_app("sqlite://")  # DB 初期化は不要なのでメモリ URL でアプリ定義だけ組み立てる
-
-    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
-
-    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
-
-
-def test_create_app_allows_single_cors_origin_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "http://localhost:3001")  # 単一 origin 指定を再現する
-
-    app = create_app("sqlite://")  # 起動前の middleware 設定だけを確認する
-
-    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
-
-    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001"]
-
-
-def test_create_app_allows_multiple_cors_origins_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(
-        "BACKEND_CORS_ORIGINS",
-        "http://localhost:3001, http://localhost:3002 ,",  # 空要素や前後空白を含む入力を正規化対象として与える
-    )
-
-    app = create_app("sqlite://")  # 設定解決結果だけを検証する
-
-    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
-
-    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3001", "http://localhost:3002"]
-
-
-def test_create_app_falls_back_to_default_cors_origin_when_env_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("BACKEND_CORS_ORIGINS", "  ,  ")  # 実質空文字の設定でも既定値へ戻す
-
-    app = create_app("sqlite://")  # 空入力時のフォールバックだけを確認する
-
-    cors_middleware = next(middleware for middleware in app.user_middleware if middleware.cls.__name__ == "CORSMiddleware")
-
-    assert cors_middleware.kwargs["allow_origins"] == ["http://localhost:3000"]
-
-
-def test_quizzes_returns_expected_shape(client: TestClient) -> None:
+def test_quizzes_returns_expected_shape(client) -> None:
     response = client.get("/quizzes")
 
     assert response.status_code == 200
@@ -83,7 +16,7 @@ def test_quizzes_returns_expected_shape(client: TestClient) -> None:
     )
 
 
-def test_quizzes_can_filter_by_eiken_level_and_question_type(client: TestClient) -> None:
+def test_quizzes_can_filter_by_eiken_level_and_question_type(client) -> None:
     response = client.get("/quizzes?eiken_levels=3&question_types=word")
 
     assert response.status_code == 200
@@ -93,7 +26,7 @@ def test_quizzes_can_filter_by_eiken_level_and_question_type(client: TestClient)
     assert all(quiz["type"] == "word" for quiz in body["quizzes"])
 
 
-def test_quizzes_can_filter_sentence_only(client: TestClient) -> None:
+def test_quizzes_can_filter_sentence_only(client) -> None:
     response = client.get("/quizzes?question_types=sentence")
 
     assert response.status_code == 200
@@ -103,7 +36,7 @@ def test_quizzes_can_filter_sentence_only(client: TestClient) -> None:
     assert all("eikenLevel" in quiz for quiz in body["quizzes"])
 
 
-def test_post_question_creates_new_sentence_question(client: TestClient) -> None:
+def test_post_question_creates_new_sentence_question(client) -> None:
     payload = {
         "eiken_level_code": "pre2",
         "question_type": "sentence",
@@ -122,7 +55,7 @@ def test_post_question_creates_new_sentence_question(client: TestClient) -> None
     assert body["isActive"] is True
 
 
-def test_get_questions_returns_registered_questions(client: TestClient) -> None:
+def test_get_questions_returns_registered_questions(client) -> None:
     created_response = client.post(
         "/questions",
         json={
@@ -150,7 +83,7 @@ def test_get_questions_returns_registered_questions(client: TestClient) -> None:
     }
 
 
-def test_patch_question_updates_existing_question(client: TestClient) -> None:
+def test_patch_question_updates_existing_question(client) -> None:
     created_response = client.post(
         "/questions",
         json={
@@ -184,13 +117,13 @@ def test_patch_question_updates_existing_question(client: TestClient) -> None:
     }
 
 
-def test_patch_question_returns_not_found_for_unknown_id(client: TestClient) -> None:
+def test_patch_question_returns_not_found_for_unknown_id(client) -> None:
     response = client.patch("/questions/999", json={"english": "ghost"})
 
     assert response.status_code == 404
 
 
-def test_post_question_rejects_invalid_master_code(client: TestClient) -> None:
+def test_post_question_rejects_invalid_master_code(client) -> None:
     response = client.post(
         "/questions",
         json={
@@ -204,7 +137,7 @@ def test_post_question_rejects_invalid_master_code(client: TestClient) -> None:
     assert response.status_code == 422
 
 
-def test_patch_question_rejects_invalid_master_code(client: TestClient) -> None:
+def test_patch_question_rejects_invalid_master_code(client) -> None:
     response = client.patch(
         "/questions/1",
         json={
@@ -215,7 +148,7 @@ def test_patch_question_rejects_invalid_master_code(client: TestClient) -> None:
     assert response.status_code == 422
 
 
-def test_post_question_rejects_whitespace_only_fields(client: TestClient) -> None:
+def test_post_question_rejects_whitespace_only_fields(client) -> None:
     response = client.post(
         "/questions",
         json={
@@ -229,7 +162,7 @@ def test_post_question_rejects_whitespace_only_fields(client: TestClient) -> Non
     assert response.status_code == 422
 
 
-def test_patch_question_rejects_whitespace_only_fields(client: TestClient) -> None:
+def test_patch_question_rejects_whitespace_only_fields(client) -> None:
     response = client.patch(
         "/questions/1",
         json={
@@ -240,7 +173,7 @@ def test_patch_question_rejects_whitespace_only_fields(client: TestClient) -> No
     assert response.status_code == 422
 
 
-def test_delete_question_deactivates_existing_question(client: TestClient) -> None:
+def test_delete_question_deactivates_existing_question(client) -> None:
     response = client.delete("/questions/1")
 
     assert response.status_code == 204
@@ -251,7 +184,7 @@ def test_delete_question_deactivates_existing_question(client: TestClient) -> No
     assert questions_response.json()["questions"][0]["isActive"] is False
 
 
-def test_quizzes_uses_active_questions_only(client: TestClient) -> None:
+def test_quizzes_uses_active_questions_only(client) -> None:
     client.delete("/questions/1")
 
     response = client.get("/quizzes")
@@ -260,173 +193,6 @@ def test_quizzes_uses_active_questions_only(client: TestClient) -> None:
     body = response.json()
     assert {quiz["type"] for quiz in body["quizzes"]} == {"word", "sentence"}
     assert all(quiz["id"] != 1 for quiz in body["quizzes"])
-
-
-def test_create_app_migrates_legacy_words_into_questions(tmp_path) -> None:
-    database_path = tmp_path / "legacy.db"
-    connection = sqlite3.connect(database_path)
-    connection.execute(
-        """
-        CREATE TABLE words (
-            id INTEGER PRIMARY KEY,
-            english TEXT NOT NULL,
-            japanese TEXT NOT NULL,
-            level INTEGER NOT NULL,
-            is_active BOOLEAN NOT NULL
-        )
-        """
-    )
-    connection.execute(
-        """
-        INSERT INTO words (id, english, japanese, level, is_active)
-        VALUES (1, 'legacy-word', '旧データ', 2, 1)
-        """
-    )
-    connection.commit()
-    connection.close()
-
-    database_url = f"sqlite:///{database_path}"
-
-    with TestClient(create_app(database_url)) as migrated_client:
-        response = migrated_client.get("/quizzes?question_types=word")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert any(
-        quiz["english"] == "legacy-word" and quiz["eikenLevel"] == "4"
-        for quiz in body["quizzes"]
-    )
-
-
-def test_create_app_applies_alembic_migrations(tmp_path) -> None:
-    database_path = tmp_path / "migrated.db"
-    database_url = f"sqlite:///{database_path}"
-
-    with TestClient(create_app(database_url)):
-        pass  # アプリ起動時の lifespan で migration 実行だけを確認する
-
-    connection = sqlite3.connect(database_path)
-    tables = {
-        row[0]
-        for row in connection.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table'"  # 作成済みテーブル一覧を取得する
-        ).fetchall()
-    }
-    connection.close()
-
-    assert {
-        "alembic_version",
-        "eiken_levels",
-        "question_types",
-        "typing_questions",
-        "study_results",
-    } <= tables
-
-
-def test_create_app_stamps_existing_schema_without_recreating_tables(tmp_path) -> None:
-    database_path = tmp_path / "existing.db"
-    database_url = f"sqlite:///{database_path}"
-    SQLModel.metadata.create_all(create_engine(database_url))  # 旧実装の create_all だけ済んだ DB を再現する
-
-    with TestClient(create_app(database_url)):
-        pass  # Alembic 導入後も既存 DB で起動できることを確認する
-
-    connection = sqlite3.connect(database_path)
-    tables = {
-        row[0]
-        for row in connection.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table'"  # テーブル一覧から stamp 結果を検証する
-        ).fetchall()
-    }
-    connection.close()
-
-    assert "alembic_version" in tables
-
-
-def test_post_study_result_persists_payload(client: TestClient) -> None:
-    payload = {
-        "mode": "learn",
-        "total_questions": 10,
-        "correct_rate": 80,
-        "mistakes": 3,
-        "average_time": 1200,
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
-
-    response = client.post("/study-results", json=payload)
-
-    assert response.status_code == 201
-    assert response.json() == payload
-
-    latest_response = client.get("/study-results/latest")
-
-    assert latest_response.status_code == 200
-    assert latest_response.json() == payload
-
-
-def test_post_study_result_rejects_invalid_payload(client: TestClient) -> None:
-    payload = {
-        "mode": "learn",
-        "total_questions": 0,
-        "correct_rate": 110,
-        "mistakes": -1,
-        "average_time": -5,
-        "created_at": "invalid-date",
-    }
-
-    response = client.post("/study-results", json=payload)
-
-    assert response.status_code == 422
-
-
-def test_today_summary_aggregates_saved_results(client: TestClient) -> None:
-    today = datetime.now(timezone.utc).isoformat()
-    yesterday = datetime(2025, 1, 1, tzinfo=timezone.utc).isoformat()
-    client.post(
-        "/study-results",
-        json={
-            "mode": "learn",
-            "total_questions": 4,
-            "correct_rate": 75,
-            "mistakes": 2,
-            "average_time": 1000,
-            "created_at": today,
-        },
-    )
-    client.post(
-        "/study-results",
-        json={
-            "mode": "review",
-            "total_questions": 6,
-            "correct_rate": 100,
-            "mistakes": 0,
-            "average_time": 900,
-            "created_at": today,
-        },
-    )
-    client.post(
-        "/study-results",
-        json={
-            "mode": "learn",
-            "total_questions": 9,
-            "correct_rate": 60,
-            "mistakes": 4,
-            "average_time": 1500,
-            "created_at": yesterday,
-        },
-    )
-
-    response = client.get("/study-results/summary/today")
-
-    assert response.status_code == 200
-    assert response.json() == {
-        "date": datetime.now(timezone.utc).date().isoformat(),
-        "sessions": 2,
-        "solvedProblems": 10,
-    }
-
-
-# _parse_csv_query の境界ケース
 
 
 def test_parse_csv_query_returns_none_for_none() -> None:
@@ -449,10 +215,7 @@ def test_parse_csv_query_ignores_trailing_comma() -> None:
     assert _parse_csv_query("word,") == ["word"]  # 入力ミスによる末尾カンマを許容し空要素は無視する仕様を検証
 
 
-# GET /questions フィルタ境界条件
-
-
-def test_get_questions_filters_by_eiken_level(client: TestClient) -> None:
+def test_get_questions_filters_by_eiken_level(client) -> None:
     client.post(
         "/questions",
         json={
@@ -479,7 +242,7 @@ def test_get_questions_filters_by_eiken_level(client: TestClient) -> None:
     assert all(q["eikenLevel"] == "5" for q in body["questions"])  # eiken_levels フィルタの仕様通り指定された級の問題のみが返却されることを検証
 
 
-def test_get_questions_filters_by_question_type(client: TestClient) -> None:
+def test_get_questions_filters_by_question_type(client) -> None:
     client.post(
         "/questions",
         json={
@@ -498,7 +261,7 @@ def test_get_questions_filters_by_question_type(client: TestClient) -> None:
     assert all(q["type"] == "sentence" for q in body["questions"])  # question_types フィルタの仕様通り指定された種別の問題のみが返却されることを検証
 
 
-def test_get_questions_excludes_inactive_when_flag_is_false(client: TestClient) -> None:
+def test_get_questions_excludes_inactive_when_flag_is_false(client) -> None:
     created = client.post(
         "/questions",
         json={
@@ -519,7 +282,7 @@ def test_get_questions_excludes_inactive_when_flag_is_false(client: TestClient) 
     assert all(q["id"] != question_id for q in body["questions"])
 
 
-def test_get_questions_combined_eiken_and_type_filter(client: TestClient) -> None:
+def test_get_questions_combined_eiken_and_type_filter(client) -> None:
     client.post(
         "/questions",
         json={
@@ -548,34 +311,19 @@ def test_get_questions_combined_eiken_and_type_filter(client: TestClient) -> Non
     assert all(q["type"] == "word" for q in body["questions"])  # 複合フィルタの仕様通り question_types 条件も同時に満たす問題のみが返却されることを検証
 
 
-# 不正 master code に対する 422
-
-
-def test_get_quizzes_returns_422_for_invalid_question_type(client: TestClient) -> None:
+def test_get_quizzes_returns_422_for_invalid_question_type(client) -> None:
     response = client.get("/quizzes?question_types=invalid_type")
 
     assert response.status_code == 422  # 不正なマスタコード値を拒否するバリデーション仕様を検証（GET /quizzes）
 
 
-def test_get_questions_returns_422_for_invalid_question_type(client: TestClient) -> None:
+def test_get_questions_returns_422_for_invalid_question_type(client) -> None:
     response = client.get("/questions?question_types=invalid_type")
 
     assert response.status_code == 422  # 不正なマスタコード値を拒否するバリデーション仕様を検証（GET /questions）
 
 
-# DELETE 存在しない ID → 404
-
-
-def test_delete_question_returns_not_found_for_unknown_id(client: TestClient) -> None:
+def test_delete_question_returns_not_found_for_unknown_id(client) -> None:
     response = client.delete("/questions/99999")
 
     assert response.status_code == 404  # 存在しないリソースへの操作を拒否するエラーハンドリング仕様を検証
-
-
-# GET /study-results/latest データ未登録 → 404
-
-
-def test_get_latest_study_result_returns_not_found_when_no_data(client: TestClient) -> None:
-    response = client.get("/study-results/latest")
-
-    assert response.status_code == 404  # データが存在しない場合のエラーハンドリング仕様を検証

--- a/backend/tests/test_study_results_api.py
+++ b/backend/tests/test_study_results_api.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timezone
+
+
+def test_post_study_result_persists_payload(client) -> None:
+    payload = {
+        "mode": "learn",
+        "total_questions": 10,
+        "correct_rate": 80,
+        "mistakes": 3,
+        "average_time": 1200,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    response = client.post("/study-results", json=payload)
+
+    assert response.status_code == 201
+    assert response.json() == payload
+
+    latest_response = client.get("/study-results/latest")
+
+    assert latest_response.status_code == 200
+    assert latest_response.json() == payload
+
+
+def test_post_study_result_rejects_invalid_payload(client) -> None:
+    payload = {
+        "mode": "learn",
+        "total_questions": 0,
+        "correct_rate": 110,
+        "mistakes": -1,
+        "average_time": -5,
+        "created_at": "invalid-date",
+    }
+
+    response = client.post("/study-results", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_today_summary_aggregates_saved_results(client) -> None:
+    today = datetime.now(timezone.utc).isoformat()
+    yesterday = datetime(2025, 1, 1, tzinfo=timezone.utc).isoformat()
+    client.post(
+        "/study-results",
+        json={
+            "mode": "learn",
+            "total_questions": 4,
+            "correct_rate": 75,
+            "mistakes": 2,
+            "average_time": 1000,
+            "created_at": today,
+        },
+    )
+    client.post(
+        "/study-results",
+        json={
+            "mode": "review",
+            "total_questions": 6,
+            "correct_rate": 100,
+            "mistakes": 0,
+            "average_time": 900,
+            "created_at": today,
+        },
+    )
+    client.post(
+        "/study-results",
+        json={
+            "mode": "learn",
+            "total_questions": 9,
+            "correct_rate": 60,
+            "mistakes": 4,
+            "average_time": 1500,
+            "created_at": yesterday,
+        },
+    )
+
+    response = client.get("/study-results/summary/today")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "date": datetime.now(timezone.utc).date().isoformat(),
+        "sessions": 2,
+        "solvedProblems": 10,
+    }
+
+
+def test_get_latest_study_result_returns_not_found_when_no_data(client) -> None:
+    response = client.get("/study-results/latest")
+
+    assert response.status_code == 404  # データが存在しない場合のエラーハンドリング仕様を検証


### PR DESCRIPTION
## What
- move the shared TestClient fixture from `backend/tests/test_main.py` into `backend/tests/conftest.py`
- split the old `test_main.py` into bootstrap/CORS+migration tests, questions/quizzes API tests, and study-results API tests
- keep the existing assertions while making each test file responsibility-focused

## Why
- make failure points easier to locate by concern
- reduce the maintenance cost of adding presentation-layer tests
- align the backend test layout with the responsibility-based structure used elsewhere in `backend/tests`

## Validation
- `backend/.venv/bin/pytest backend/tests`

Closes #32