### PR TITLE
refactor: split question and quiz api tests

### DIFF
--- a/backend/tests/test_questions_api.py
+++ b/backend/tests/test_questions_api.py
@@ -1,41 +1,6 @@
 from backend.presentation.api import _parse_csv_query
 
 
-def test_quizzes_returns_expected_shape(client) -> None:
-    response = client.get("/quizzes")
-
-    assert response.status_code == 200
-
-    body = response.json()
-    assert "quizzes" in body
-    assert len(body["quizzes"]) > 0
-    assert {quiz["type"] for quiz in body["quizzes"]} == {"word", "sentence"}
-    assert all(
-        {"id", "type", "english", "japanese", "eikenLevel"} <= set(quiz.keys())
-        for quiz in body["quizzes"]
-    )
-
-
-def test_quizzes_can_filter_by_eiken_level_and_question_type(client) -> None:
-    response = client.get("/quizzes?eiken_levels=3&question_types=word")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert len(body["quizzes"]) > 0
-    assert all(quiz["eikenLevel"] == "3" for quiz in body["quizzes"])
-    assert all(quiz["type"] == "word" for quiz in body["quizzes"])
-
-
-def test_quizzes_can_filter_sentence_only(client) -> None:
-    response = client.get("/quizzes?question_types=sentence")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert len(body["quizzes"]) > 0
-    assert all(quiz["type"] == "sentence" for quiz in body["quizzes"])
-    assert all("eikenLevel" in quiz for quiz in body["quizzes"])
-
-
 def test_post_question_creates_new_sentence_question(client) -> None:
     payload = {
         "eiken_level_code": "pre2",
@@ -184,17 +149,6 @@ def test_delete_question_deactivates_existing_question(client) -> None:
     assert questions_response.json()["questions"][0]["isActive"] is False
 
 
-def test_quizzes_uses_active_questions_only(client) -> None:
-    client.delete("/questions/1")
-
-    response = client.get("/quizzes")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert {quiz["type"] for quiz in body["quizzes"]} == {"word", "sentence"}
-    assert all(quiz["id"] != 1 for quiz in body["quizzes"])
-
-
 def test_parse_csv_query_returns_none_for_none() -> None:
     assert _parse_csv_query(None) is None  # クエリパラメータ未指定時はフィルタを適用しないため None を返すことを検証
 
@@ -309,12 +263,6 @@ def test_get_questions_combined_eiken_and_type_filter(client) -> None:
     assert len(body["questions"]) > 0
     assert all(q["eikenLevel"] == "pre2" for q in body["questions"])  # 複合フィルタの仕様通り eiken_levels 条件を満たす問題のみが返却されることを検証
     assert all(q["type"] == "word" for q in body["questions"])  # 複合フィルタの仕様通り question_types 条件も同時に満たす問題のみが返却されることを検証
-
-
-def test_get_quizzes_returns_422_for_invalid_question_type(client) -> None:
-    response = client.get("/quizzes?question_types=invalid_type")
-
-    assert response.status_code == 422  # 不正なマスタコード値を拒否するバリデーション仕様を検証（GET /quizzes）
 
 
 def test_get_questions_returns_422_for_invalid_question_type(client) -> None:

--- a/backend/tests/test_quizzes_api.py
+++ b/backend/tests/test_quizzes_api.py
@@ -1,0 +1,50 @@
+def test_quizzes_returns_expected_shape(client) -> None:
+    response = client.get("/quizzes")
+
+    assert response.status_code == 200
+
+    body = response.json()
+    assert "quizzes" in body
+    assert len(body["quizzes"]) > 0
+    assert {quiz["type"] for quiz in body["quizzes"]} == {"word", "sentence"}
+    assert all(
+        {"id", "type", "english", "japanese", "eikenLevel"} <= set(quiz.keys())
+        for quiz in body["quizzes"]
+    )
+
+
+def test_quizzes_can_filter_by_eiken_level_and_question_type(client) -> None:
+    response = client.get("/quizzes?eiken_levels=3&question_types=word")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["quizzes"]) > 0
+    assert all(quiz["eikenLevel"] == "3" for quiz in body["quizzes"])
+    assert all(quiz["type"] == "word" for quiz in body["quizzes"])
+
+
+def test_quizzes_can_filter_sentence_only(client) -> None:
+    response = client.get("/quizzes?question_types=sentence")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["quizzes"]) > 0
+    assert all(quiz["type"] == "sentence" for quiz in body["quizzes"])
+    assert all("eikenLevel" in quiz for quiz in body["quizzes"])
+
+
+def test_quizzes_uses_active_questions_only(client) -> None:
+    client.delete("/questions/1")
+
+    response = client.get("/quizzes")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert {quiz["type"] for quiz in body["quizzes"]} == {"word", "sentence"}
+    assert all(quiz["id"] != 1 for quiz in body["quizzes"])
+
+
+def test_get_quizzes_returns_422_for_invalid_question_type(client) -> None:
+    response = client.get("/quizzes?question_types=invalid_type")
+
+    assert response.status_code == 422  # 不正なマスタコード値を拒否するバリデーション仕様を検証（GET /quizzes）


### PR DESCRIPTION
## What
- rename the mixed API test file to `backend/tests/test_questions_api.py`
- move `/quizzes` API assertions into `backend/tests/test_quizzes_api.py`
- keep question-specific CRUD, filter, and validation checks in the questions test file

## Why
- separate question and quiz concerns at the test file level
- make API failures easier to localize by resource
- align the backend test layout with issue #45

## Validation
- `backend/.venv/bin/pytest backend/tests`

Closes #45


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated quiz endpoint tests into a dedicated module with comprehensive validation coverage including response structure and required fields, filtering by difficulty level and question type, sentence-only filtering, active question enforcement, and error handling for invalid query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->