### PR TITLE
feat: ホーム画面の学習条件をタグ選択へ移行

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -26,7 +26,8 @@ const sampleQuestions: Question[] = [
     eikenLevel: "5",
     english: "apple",
     japanese: "りんご",
-    isActive: true
+    isActive: true,
+    tags: ["word", "daily"]
   }
 ];
 
@@ -60,12 +61,11 @@ describe("study result api", () => {
 
     await expect(
       fetchStudyQuestions({
-        eikenLevels: ["3", "pre2"],
-        questionTypes: ["word"]
+        tags: ["business", "daily"]
       })
     ).resolves.toEqual(sampleQuestions);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8000/questions?eiken_levels=3%2Cpre2&question_types=word&include_inactive=false",
+      "http://localhost:8000/questions?tags=business%2Cdaily&include_inactive=false",
       expect.objectContaining({ cache: "no-store" })
     );
   });
@@ -138,12 +138,12 @@ describe("study result api", () => {
     await expect(
       fetchQuestionListResponse({
         eikenLevels: ["3", "pre2"],
-        questionTypes: ["word"],
+        tags: ["business"],
         includeInactive: false
       })
     ).resolves.toEqual({ questions: sampleQuestions });
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8000/questions?eiken_levels=3%2Cpre2&question_types=word&include_inactive=false",
+      "http://localhost:8000/questions?eiken_levels=3%2Cpre2&tags=business&include_inactive=false",
       expect.objectContaining({ cache: "no-store" })
     );
   });

--- a/frontend/src/__tests__/homeDashboardUi.test.tsx
+++ b/frontend/src/__tests__/homeDashboardUi.test.tsx
@@ -7,18 +7,15 @@ import {
 } from "@/features/home-dashboard/ui/HomeDashboard";
 
 const baseProps: HomeDashboardViewProps = {
-  settings: {
-    eikenLevels: ["5"],
-    questionTypes: ["word", "sentence"]
-  },
+  settings: { tags: ["word", "business"] },
+  availableTags: ["word", "business", "daily"],
   summary: {
     date: "2026-03-22",
     sessions: 2,
     solvedProblems: 16,
     reviewBacklog: 3
   },
-  onSelectEikenLevel: vi.fn(),
-  onToggleQuestionType: vi.fn()
+  onToggleTag: vi.fn()
 };
 
 describe("home dashboard ui", () => {
@@ -28,5 +25,14 @@ describe("home dashboard ui", () => {
     expect(html).toContain("登録問題を確認する");
     expect(html).toContain("href=\"/questions\"");
     expect(html).toContain("typing_questions の一覧を閲覧できます。");
+  });
+
+  it("renders tag selection ui and explains empty selection behavior", () => {
+    const html = renderToStaticMarkup(<HomeDashboardView {...baseProps} />);
+
+    expect(html).toContain("出題タグ");
+    expect(html).toContain("business");
+    expect(html).toContain("daily");
+    expect(html).toContain("タグ未選択時はすべてのタグを対象に出題します。");
   });
 });

--- a/frontend/src/__tests__/homeDashboardUsecases.test.ts
+++ b/frontend/src/__tests__/homeDashboardUsecases.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   createHomeDashboardModel,
-  selectEikenLevel,
-  toggleQuestionType
+  toggleTag
 } from "@/features/home-dashboard/application/homeDashboard";
 import type { DailySummary, Settings } from "@/shared/types/study";
 
 const settings: Settings = {
-  eikenLevels: ["5"],
-  questionTypes: ["word", "sentence"]
+  tags: ["word", "sentence"]
 };
 
 const localSummary: DailySummary = {
@@ -40,23 +38,15 @@ describe("home dashboard use cases", () => {
     });
   });
 
-  it("replaces the selected eiken level", () => {
-    expect(selectEikenLevel(settings, "pre2")).toEqual({
-      eikenLevels: ["pre2"],
-      questionTypes: ["word", "sentence"]
+  it("toggles tags and allows clearing all tags", () => {
+    expect(toggleTag(settings, "word")).toEqual({
+      tags: ["sentence"]
     });
-  });
-
-  it("does not allow removing the last question type", () => {
-    const wordOnly: Settings = {
-      eikenLevels: ["5"],
-      questionTypes: ["word"]
-    };
-
-    expect(toggleQuestionType(settings, "word")).toEqual({
-      eikenLevels: ["5"],
-      questionTypes: ["sentence"]
+    expect(toggleTag({ tags: ["word"] }, "word")).toEqual({
+      tags: []
     });
-    expect(toggleQuestionType(wordOnly, "word")).toEqual(wordOnly);
+    expect(toggleTag(settings, "business")).toEqual({
+      tags: ["word", "sentence", "business"]
+    });
   });
 });

--- a/frontend/src/__tests__/questionBrowserUi.test.tsx
+++ b/frontend/src/__tests__/questionBrowserUi.test.tsx
@@ -61,7 +61,8 @@ describe("question browser ui", () => {
             eikenLevel: "5",
             english: "apple",
             japanese: "りんご",
-            isActive: true
+            isActive: true,
+            tags: ["word"]
           },
           {
             id: 2,
@@ -69,7 +70,8 @@ describe("question browser ui", () => {
             eikenLevel: "pre2",
             english: "We must protect the environment.",
             japanese: "私たちは環境を守らなければならない。",
-            isActive: false
+            isActive: false,
+            tags: ["sentence", "environment"]
           }
         ]}
         status="loaded"

--- a/frontend/src/__tests__/questionBrowserUsecases.test.ts
+++ b/frontend/src/__tests__/questionBrowserUsecases.test.ts
@@ -13,7 +13,8 @@ const sampleQuestions: Question[] = [
     eikenLevel: "5",
     english: "apple",
     japanese: "りんご",
-    isActive: true
+    isActive: true,
+    tags: ["word"]
   }
 ];
 

--- a/frontend/src/__tests__/storage.test.ts
+++ b/frontend/src/__tests__/storage.test.ts
@@ -29,20 +29,33 @@ afterEach(() => {
 });
 
 describe("storage settings", () => {
-  it("normalizes malformed saved settings before returning them", () => {
+  it("normalizes malformed saved tag settings before returning them", () => {
     const { storage } = setupWindow();
 
     storage.set(
       SETTINGS_KEY,
       JSON.stringify({
-        eikenLevels: ["3", "pre2", "0", null],
-        questionTypes: ["sentence", "word", "other", "word"]
+        tags: [" speaking ", "daily", "", "daily", 1]
       })
     );
 
     expect(getSettings()).toEqual({
-      eikenLevels: ["3", "pre2"],
-      questionTypes: ["sentence", "word"]
+      tags: ["speaking", "daily"]
+    });
+  });
+
+  it("returns default settings when tags are not saved", () => {
+    const { storage } = setupWindow();
+
+    storage.set(
+      SETTINGS_KEY,
+      JSON.stringify({
+        questionTypes: ["sentence", "word", "sentence"]
+      })
+    );
+
+    expect(getSettings()).toEqual({
+      tags: []
     });
   });
 
@@ -50,14 +63,12 @@ describe("storage settings", () => {
     const { localStorageMock, storage } = setupWindow();
 
     saveSettings({
-      eikenLevels: ["pre2", "pre2", "2", "invalid"],
-      questionTypes: ["word", "word", "sentence", "invalid"]
+      tags: [" Writing ", "writing", "daily", ""]
     } as Settings);
 
     expect(localStorageMock.setItem).toHaveBeenCalledTimes(1);
     expect(JSON.parse(storage.get(SETTINGS_KEY) ?? "null")).toEqual({
-      eikenLevels: ["pre2", "2"],
-      questionTypes: ["word", "sentence"]
+      tags: ["writing", "daily"]
     });
   });
 });

--- a/frontend/src/__tests__/study.test.ts
+++ b/frontend/src/__tests__/study.test.ts
@@ -11,17 +11,17 @@ import {
 import type { Question } from "@/shared/types/study";
 
 const quizzes: Question[] = [
-  { id: 1, type: "word", eikenLevel: "5", english: "apple", japanese: "りんご", isActive: true },
-  { id: 2, type: "word", eikenLevel: "5", english: "library", japanese: "図書館", isActive: true },
-  { id: 3, type: "word", eikenLevel: "4", english: "beautiful", japanese: "美しい", isActive: true },
-  { id: 4, type: "word", eikenLevel: "4", english: "schedule", japanese: "予定", isActive: true },
-  { id: 5, type: "word", eikenLevel: "3", english: "environment", japanese: "環境", isActive: true },
-  { id: 6, type: "sentence", eikenLevel: "5", english: "I drink coffee every morning.", japanese: "私は毎朝コーヒーを飲みます。", isActive: true },
-  { id: 7, type: "sentence", eikenLevel: "4", english: "We need to finish this report today.", japanese: "私たちは今日このレポートを終える必要があります。", isActive: true },
-  { id: 8, type: "sentence", eikenLevel: "3", english: "Small daily habits often create meaningful progress.", japanese: "小さな毎日の習慣が大きな前進を生みます。", isActive: true },
-  { id: 9, type: "word", eikenLevel: "5", english: "practice", japanese: "練習", isActive: true },
-  { id: 10, type: "word", eikenLevel: "4", english: "through", japanese: "通り抜けて", isActive: true },
-  { id: 11, type: "word", eikenLevel: "3", english: "confidence", japanese: "自信", isActive: true }
+  { id: 1, type: "word", eikenLevel: "5", english: "apple", japanese: "りんご", isActive: true, tags: ["word", "daily"] },
+  { id: 2, type: "word", eikenLevel: "5", english: "library", japanese: "図書館", isActive: true, tags: ["word", "school"] },
+  { id: 3, type: "word", eikenLevel: "4", english: "beautiful", japanese: "美しい", isActive: true, tags: ["word", "expression"] },
+  { id: 4, type: "word", eikenLevel: "4", english: "schedule", japanese: "予定", isActive: true, tags: ["word", "business"] },
+  { id: 5, type: "word", eikenLevel: "3", english: "environment", japanese: "環境", isActive: true, tags: ["word", "science"] },
+  { id: 6, type: "sentence", eikenLevel: "5", english: "I drink coffee every morning.", japanese: "私は毎朝コーヒーを飲みます。", isActive: true, tags: ["sentence", "daily"] },
+  { id: 7, type: "sentence", eikenLevel: "4", english: "We need to finish this report today.", japanese: "私たちは今日このレポートを終える必要があります。", isActive: true, tags: ["sentence", "business"] },
+  { id: 8, type: "sentence", eikenLevel: "3", english: "Small daily habits often create meaningful progress.", japanese: "小さな毎日の習慣が大きな前進を生みます。", isActive: true, tags: ["sentence", "daily"] },
+  { id: 9, type: "word", eikenLevel: "5", english: "practice", japanese: "練習", isActive: true, tags: ["word", "daily"] },
+  { id: 10, type: "word", eikenLevel: "4", english: "through", japanese: "通り抜けて", isActive: true, tags: ["word", "travel"] },
+  { id: 11, type: "word", eikenLevel: "3", english: "confidence", japanese: "自信", isActive: true, tags: ["word", "mindset"] }
 ];
 
 describe("study utilities", () => {
@@ -36,7 +36,7 @@ describe("study utilities", () => {
   });
 
   it("returns random ten questions in learn mode", () => {
-    const learnQuizzes = buildQuizSet(quizzes, "learn", [], ["5", "4", "3"], ["word", "sentence"]);
+    const learnQuizzes = buildQuizSet(quizzes, "learn", [], []);
 
     expect(learnQuizzes).toHaveLength(SESSION_QUESTION_COUNT);
     expect(new Set(learnQuizzes.map((quiz) => quiz.id)).size).toBe(SESSION_QUESTION_COUNT);
@@ -45,32 +45,28 @@ describe("study utilities", () => {
     ).toBe(true);
   });
 
-  it("filters learn quizzes by specified levels", () => {
-    const level1Only = buildQuizSet(quizzes, "learn", [], ["5"], ["word", "sentence"]);
+  it("filters learn quizzes by tags", () => {
+    const businessOnly = buildQuizSet(quizzes, "learn", [], ["business"]);
 
-    expect(level1Only.length).toBeGreaterThan(0);
-    expect(level1Only.every((quiz) => quiz.eikenLevel === "5")).toBe(true);
+    expect(businessOnly.length).toBeGreaterThan(0);
+    expect(businessOnly.every((quiz) => quiz.tags.includes("business"))).toBe(true);
   });
 
-  it("filters learn quizzes by question type", () => {
-    const sentenceOnly = buildQuizSet(quizzes, "learn", [], ["5", "4", "3"], ["sentence"]);
-
-    expect(sentenceOnly.length).toBeGreaterThan(0);
-    expect(sentenceOnly.every((quiz) => quiz.type === "sentence")).toBe(true);
-  });
-
-  it("filters learn quizzes by eiken level and question type together", () => {
-    const filtered = buildQuizSet(quizzes, "learn", [], ["4"], ["word"]);
+  it("filters learn quizzes when multiple tags are specified", () => {
+    const filtered = buildQuizSet(quizzes, "learn", [], ["business", "travel"]);
 
     expect(filtered.length).toBeGreaterThan(0);
-    expect(filtered.every((quiz) => quiz.eikenLevel === "4")).toBe(true);
-    expect(filtered.every((quiz) => quiz.type === "word")).toBe(true);
+    expect(
+      filtered.every((quiz) =>
+        quiz.tags.some((tag) => ["business", "travel"].includes(tag))
+      )
+    ).toBe(true);
   });
 
   it("does not apply learn filters in review mode", () => {
     const level5Id = quizzes.find((quiz) => quiz.eikenLevel === "5")!.id;
     const level3Id = quizzes.find((quiz) => quiz.eikenLevel === "3")!.id;
-    const reviewQuizzes = buildQuizSet(quizzes, "review", [level5Id, level3Id], ["5"], ["word"]);
+    const reviewQuizzes = buildQuizSet(quizzes, "review", [level5Id, level3Id], ["business"]);
 
     expect(reviewQuizzes).toHaveLength(2);
     const ids = reviewQuizzes.map((quiz) => quiz.id).sort((a, b) => a - b);

--- a/frontend/src/__tests__/studySessionUsecases.test.ts
+++ b/frontend/src/__tests__/studySessionUsecases.test.ts
@@ -6,14 +6,13 @@ import {
 import type { Question, QuizProgress, Settings } from "@/shared/types/study";
 
 const settings: Settings = {
-  eikenLevels: ["5", "4"],
-  questionTypes: ["word", "sentence"]
+  tags: ["word", "sentence"]
 };
 
 const quizzes: Question[] = [
-  { id: 1, type: "word", eikenLevel: "5", english: "apple", japanese: "りんご", isActive: true },
-  { id: 2, type: "word", eikenLevel: "4", english: "library", japanese: "図書館", isActive: true },
-  { id: 3, type: "sentence", eikenLevel: "3", english: "I read books.", japanese: "私は本を読みます。", isActive: true }
+  { id: 1, type: "word", eikenLevel: "5", english: "apple", japanese: "りんご", isActive: true, tags: ["word", "daily"] },
+  { id: 2, type: "word", eikenLevel: "4", english: "library", japanese: "図書館", isActive: true, tags: ["word", "school"] },
+  { id: 3, type: "sentence", eikenLevel: "3", english: "I read books.", japanese: "私は本を読みます。", isActive: true, tags: ["sentence", "daily"] }
 ];
 
 describe("study session use cases", () => {
@@ -26,8 +25,8 @@ describe("study session use cases", () => {
       sessionQuestionCount: 10
     });
 
-    expect(result.quizSet.length).toBe(2);
-    expect(result.quizSet.every((quiz) => settings.eikenLevels.includes(quiz.eikenLevel))).toBe(true);
+    expect(result.quizSet.length).toBe(3);
+    expect(result.quizSet.every((quiz) => quiz.tags.some((tag) => settings.tags.includes(tag)))).toBe(true);
     expect(result.isEmptyQuizSet).toBe(false);
   });
 
@@ -36,10 +35,7 @@ describe("study session use cases", () => {
       questions: quizzes,
       mode: "learn",
       reviewQueue: [],
-      settings: {
-        eikenLevels: ["1"],
-        questionTypes: ["word"]
-      },
+      settings: { tags: ["unknown"] },
       sessionQuestionCount: 10
     });
 

--- a/frontend/src/features/home-dashboard/api/homeDashboardApi.ts
+++ b/frontend/src/features/home-dashboard/api/homeDashboardApi.ts
@@ -1,5 +1,21 @@
-import { fetchTodayStudySummaryResponse } from "@/shared/api/studyApiClient";
+import {
+  fetchQuestionListResponse,
+  fetchTodayStudySummaryResponse
+} from "@/shared/api/studyApiClient";
 
 export async function fetchTodayStudySummary(signal?: AbortSignal) {
   return fetchTodayStudySummaryResponse(signal);
+}
+
+export async function fetchAvailableTags(signal?: AbortSignal): Promise<string[]> {
+  const response = await fetchQuestionListResponse(
+    {
+      includeInactive: false
+    },
+    signal
+  );
+
+  return Array.from(
+    new Set(response.questions.flatMap((question) => question.tags))
+  ).sort((left, right) => left.localeCompare(right));
 }

--- a/frontend/src/features/home-dashboard/application/homeDashboard.ts
+++ b/frontend/src/features/home-dashboard/application/homeDashboard.ts
@@ -1,7 +1,5 @@
 import type {
   DailySummary,
-  EikenLevel,
-  QuizType,
   Settings
 } from "@/shared/types/study";
 import type { StudySummaryResponseDto } from "@/shared/api/studyApiTypes";
@@ -9,12 +7,14 @@ import type { StudySummaryResponseDto } from "@/shared/api/studyApiTypes";
 export type HomeDashboardDto = {
   summary: DailySummary;
   settings: Settings;
+  availableTags: string[];
 };
 
 type CreateHomeDashboardInput = {
   settings: Settings;
   reviewQueueCount: number;
   localSummary: DailySummary;
+  availableTags?: string[];
   remoteSummary?: StudySummaryResponseDto | null;
 };
 
@@ -22,30 +22,23 @@ export function createHomeDashboardModel({
   settings,
   reviewQueueCount,
   localSummary,
+  availableTags = [],
   remoteSummary = null
 }: CreateHomeDashboardInput): HomeDashboardDto {
   const summary = remoteSummary
     ? { ...remoteSummary, reviewBacklog: reviewQueueCount }
     : { ...localSummary, reviewBacklog: reviewQueueCount };
 
-  return { summary, settings };
+  return { summary, settings, availableTags };
 }
 
-export function selectEikenLevel(settings: Settings, eikenLevel: EikenLevel): Settings {
-  return {
-    ...settings,
-    eikenLevels: [eikenLevel]
-  };
-}
-
-export function toggleQuestionType(settings: Settings, questionType: QuizType): Settings {
-  const nextQuestionTypes = settings.questionTypes.includes(questionType)
-    ? settings.questionTypes.filter((value) => value !== questionType)
-    : [...settings.questionTypes, questionType];
+export function toggleTag(settings: Settings, tag: string): Settings {
+  const nextTags = settings.tags.includes(tag)
+    ? settings.tags.filter((value) => value !== tag)
+    : [...settings.tags, tag];
 
   return {
     ...settings,
-    questionTypes:
-      nextQuestionTypes.length > 0 ? nextQuestionTypes : settings.questionTypes
+    tags: nextTags
   };
 }

--- a/frontend/src/features/home-dashboard/hooks/useHomeDashboard.ts
+++ b/frontend/src/features/home-dashboard/hooks/useHomeDashboard.ts
@@ -3,18 +3,19 @@
 import { useEffect, useState } from "react";
 import {
   createHomeDashboardModel,
-  selectEikenLevel,
-  toggleQuestionType
+  toggleTag
 } from "@/features/home-dashboard/application/homeDashboard";
 import type { HomeDashboardDto } from "@/features/home-dashboard/application/homeDashboard";
-import { fetchTodayStudySummary } from "@/features/home-dashboard/api/homeDashboardApi";
+import {
+  fetchAvailableTags,
+  fetchTodayStudySummary
+} from "@/features/home-dashboard/api/homeDashboardApi";
 import {
   getReviewQueue,
   getSettings,
   getTodaySummary,
   saveSettings
 } from "@/features/home-dashboard/storage/homeDashboardStorage";
-import type { EikenLevel, QuizType } from "@/shared/types/study";
 
 function createFallbackDashboard(): HomeDashboardDto {
   return {
@@ -24,10 +25,8 @@ function createFallbackDashboard(): HomeDashboardDto {
       solvedProblems: 0,
       reviewBacklog: 0
     },
-    settings: {
-      eikenLevels: ["5"],
-      questionTypes: ["word", "sentence"]
-    }
+    settings: { tags: [] },
+    availableTags: []
   }; // 初期表示で空のダッシュボード状態を返す
 }
 
@@ -35,16 +34,26 @@ export function useHomeDashboard() {
   const [dashboard, setDashboard] = useState<HomeDashboardDto>(createFallbackDashboard);
 
   useEffect(() => {
+    const abortController = new AbortController();
     let isDisposed = false;
 
     const loadDashboard = async () => {
       const settings = getSettings();
       const reviewQueueCount = getReviewQueue().length;
       const localSummary = getTodaySummary();
+      let availableTags: string[] = [];
+
+      try {
+        availableTags = await fetchAvailableTags(abortController.signal);
+      } catch {
+        availableTags = [];
+      }
+
       const localDashboard = createHomeDashboardModel({
         settings,
         reviewQueueCount,
-        localSummary
+        localSummary,
+        availableTags
       });
 
       if (!isDisposed) {
@@ -52,7 +61,7 @@ export function useHomeDashboard() {
       }
 
       try {
-        const remoteSummary = await fetchTodayStudySummary();
+        const remoteSummary = await fetchTodayStudySummary(abortController.signal);
 
         if (isDisposed) {
           return;
@@ -63,6 +72,7 @@ export function useHomeDashboard() {
             settings,
             reviewQueueCount,
             localSummary,
+            availableTags,
             remoteSummary
           })
         );
@@ -76,25 +86,14 @@ export function useHomeDashboard() {
     void loadDashboard();
 
     return () => {
+      abortController.abort();
       isDisposed = true;
     };
   }, []);
 
-  const handleSelectEikenLevel = (eikenLevel: EikenLevel) => {
+  const handleToggleTag = (tag: string) => {
     setDashboard((current) => {
-      const nextSettings = selectEikenLevel(current.settings, eikenLevel);
-      saveSettings(nextSettings);
-
-      return {
-        ...current,
-        settings: nextSettings
-      };
-    });
-  };
-
-  const handleToggleQuestionType = (questionType: QuizType) => {
-    setDashboard((current) => {
-      const nextSettings = toggleQuestionType(current.settings, questionType);
+      const nextSettings = toggleTag(current.settings, tag);
       saveSettings(nextSettings);
 
       return {
@@ -107,7 +106,7 @@ export function useHomeDashboard() {
   return {
     summary: dashboard.summary,
     settings: dashboard.settings,
-    selectEikenLevel: handleSelectEikenLevel,
-    toggleQuestionType: handleToggleQuestionType
+    availableTags: dashboard.availableTags,
+    toggleTag: handleToggleTag
   };
 }

--- a/frontend/src/features/home-dashboard/ui/HomeDashboard.tsx
+++ b/frontend/src/features/home-dashboard/ui/HomeDashboard.tsx
@@ -3,35 +3,19 @@
 import React from "react";
 import Link from "next/link";
 import { useHomeDashboard } from "@/features/home-dashboard/hooks/useHomeDashboard";
-import type { EikenLevel, QuizType } from "@/shared/types/study";
 import type { DailySummary, Settings } from "@/shared/types/study";
-
-const EIKEN_LEVEL_OPTIONS: { value: EikenLevel; label: string }[] = [
-  { value: "5", label: "英検5級" },
-  { value: "4", label: "英検4級" },
-  { value: "3", label: "英検3級" },
-  { value: "pre2", label: "英検準2級" },
-  { value: "2", label: "英検2級" },
-  { value: "pre1", label: "英検準1級" },
-  { value: "1", label: "英検1級" }
-];
-const QUESTION_TYPE_OPTIONS: { value: QuizType; label: string }[] = [
-  { value: "word", label: "英単語" },
-  { value: "sentence", label: "英文章" }
-];
-
 export type HomeDashboardViewProps = {
   settings: Settings;
+  availableTags: string[];
   summary: DailySummary;
-  onSelectEikenLevel: (eikenLevel: EikenLevel) => void;
-  onToggleQuestionType: (questionType: QuizType) => void;
+  onToggleTag: (tag: string) => void;
 };
 
 export function HomeDashboardView({
   settings,
+  availableTags,
   summary,
-  onSelectEikenLevel,
-  onToggleQuestionType
+  onToggleTag
 }: HomeDashboardViewProps) {
   return (
     <main className="page-shell">
@@ -79,47 +63,36 @@ export function HomeDashboardView({
       </section>
 
       <section className="settings-section">
-        <label className="settings-label" htmlFor="level-select">
-          出題英検級（通常学習）
-        </label>
-        <select
-          className="level-select"
-          id="level-select"
-          onChange={(event) => onSelectEikenLevel(event.target.value as EikenLevel)}
-          value={settings.eikenLevels[0]}
-        >
-          {EIKEN_LEVEL_OPTIONS.map((level) => (
-            <option key={level.value} value={level.value}>
-              {level.label}
-            </option>
-          ))}
-        </select>
-
-        <p className="settings-label settings-subtitle">出題タイプ</p>
-        <div className="settings-chip-group">
-          {QUESTION_TYPE_OPTIONS.map((option) => (
-            <label className="settings-chip" key={option.value}>
-              <input
-                checked={settings.questionTypes.includes(option.value)}
-                onChange={() => onToggleQuestionType(option.value)}
-                type="checkbox"
-              />
-              <span>{option.label}</span>
-            </label>
-          ))}
-        </div>
+        <p className="settings-label">出題タグ</p>
+        <p className="settings-caption">タグ未選択時はすべてのタグを対象に出題します。</p>
+        {availableTags.length > 0 ? (
+          <div className="settings-chip-group">
+            {availableTags.map((tag) => (
+              <label className="settings-chip" key={tag}>
+                <input
+                  checked={settings.tags.includes(tag)}
+                  onChange={() => onToggleTag(tag)}
+                  type="checkbox"
+                />
+                <span>{tag}</span>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <p className="settings-caption">利用可能なタグはまだありません。</p>
+        )}
       </section>
     </main>
   );
 }
 
 export function HomeDashboard() {
-  const { settings, summary, selectEikenLevel, toggleQuestionType } = useHomeDashboard();
+  const { settings, availableTags, summary, toggleTag } = useHomeDashboard();
 
   return (
     <HomeDashboardView
-      onSelectEikenLevel={selectEikenLevel}
-      onToggleQuestionType={toggleQuestionType}
+      availableTags={availableTags}
+      onToggleTag={toggleTag}
       settings={settings}
       summary={summary}
     />

--- a/frontend/src/features/study-session/api/studySessionApi.ts
+++ b/frontend/src/features/study-session/api/studySessionApi.ts
@@ -2,11 +2,10 @@ import {
   fetchQuestionListResponse,
   postStudyResult
 } from "@/shared/api/studyApiClient";
-import type { EikenLevel, Question, QuizType, StudyResult } from "@/shared/types/study";
+import type { Question, StudyResult } from "@/shared/types/study";
 
 export type FetchStudyQuestionsOptions = {
-  eikenLevels?: EikenLevel[];
-  questionTypes?: QuizType[];
+  tags?: string[];
 };
 
 export async function fetchStudyQuestions(

--- a/frontend/src/features/study-session/application/studySession.ts
+++ b/frontend/src/features/study-session/application/studySession.ts
@@ -51,8 +51,7 @@ export function startStudySession({
     questions,
     mode,
     reviewQueue,
-    settings.eikenLevels,
-    settings.questionTypes,
+    settings.tags,
     sessionQuestionCount
   );
 

--- a/frontend/src/features/study-session/hooks/useStudySession.ts
+++ b/frontend/src/features/study-session/hooks/useStudySession.ts
@@ -92,8 +92,7 @@ export function useStudySession(mode: StudyMode): UseStudySessionResult {
         const questions = await fetchStudyQuestions(
           mode === "learn"
             ? {
-                eikenLevels: settings.eikenLevels,
-                questionTypes: settings.questionTypes
+                tags: settings.tags
               }
             : {},
           abortController.signal

--- a/frontend/src/features/study-session/model/session.ts
+++ b/frontend/src/features/study-session/model/session.ts
@@ -1,8 +1,6 @@
 import type {
-  EikenLevel,
   Question,
   QuizProgress,
-  QuizType,
   StudyMode,
   StudyResult
 } from "@/shared/types/study";
@@ -24,8 +22,7 @@ export function buildQuizSet(
   quizzes: Question[],
   mode: StudyMode,
   missedIds: number[],
-  eikenLevels: EikenLevel[] = ["5", "4", "3", "pre2", "2", "pre1", "1"],
-  questionTypes: QuizType[] = ["word", "sentence"],
+  tags: string[] = [],
   sessionQuestionCount = SESSION_QUESTION_COUNT
 ): Question[] {
   if (mode === "review") {
@@ -35,9 +32,7 @@ export function buildQuizSet(
   }
 
   const filtered = quizzes.filter(
-    (quiz) =>
-      (eikenLevels.length === 0 || eikenLevels.includes(quiz.eikenLevel)) &&
-      (questionTypes.length === 0 || questionTypes.includes(quiz.type))
+    (quiz) => tags.length === 0 || tags.some((tag) => quiz.tags.includes(tag))
   );
   return shuffleQuizzes(filtered).slice(0, Math.min(sessionQuestionCount, filtered.length));
 }

--- a/frontend/src/shared/api/studyApiClient.ts
+++ b/frontend/src/shared/api/studyApiClient.ts
@@ -17,6 +17,7 @@ function getApiBaseUrl(): string {
 export type FetchQuestionListOptions = {
   eikenLevels?: EikenLevel[];
   questionTypes?: QuizType[];
+  tags?: string[];
   includeInactive?: boolean;
 };
 
@@ -40,6 +41,10 @@ export async function fetchQuestionListResponse(
 
   if (options.questionTypes && options.questionTypes.length > 0) {
     searchParams.set("question_types", options.questionTypes.join(",")); // 問題種別フィルタを API 契約へ変換する
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    searchParams.set("tags", options.tags.join(",")); // タグフィルタを API 契約へ変換する
   }
 
   if (options.includeInactive !== undefined) {

--- a/frontend/src/shared/lib/studyLocalStorage.ts
+++ b/frontend/src/shared/lib/studyLocalStorage.ts
@@ -10,92 +10,39 @@ const MISTAKE_LOG_KEY = "typing-app::mistake_log";
 const STUDY_RESULT_KEY = "typing-app::study_result";
 const LATEST_RESULT_KEY = "typing-app::latest-result";
 const SETTINGS_KEY = "typing-app::settings";
-const AVAILABLE_EIKEN_LEVELS = ["5", "4", "3", "pre2", "2", "pre1", "1"] as const;
-const AVAILABLE_QUESTION_TYPES = ["word", "sentence"] as const;
-const LEGACY_LEVEL_TO_EIKEN_LEVEL: Record<number, (typeof AVAILABLE_EIKEN_LEVELS)[number]> = {
-  1: "5",
-  2: "4",
-  3: "3"
-};
 
 const DEFAULT_SETTINGS: Settings = {
-  eikenLevels: ["5"],
-  questionTypes: ["word", "sentence"]
+  tags: []
 };
 
-function normalizeEikenLevel(level: unknown): Settings["eikenLevels"][number] | null {
-  if (typeof level === "string") {
-    const normalizedLevel = level.trim();
-
-    return AVAILABLE_EIKEN_LEVELS.includes(
-      normalizedLevel as (typeof AVAILABLE_EIKEN_LEVELS)[number]
-    )
-      ? (normalizedLevel as (typeof AVAILABLE_EIKEN_LEVELS)[number])
-      : null;
-  }
-
-  if (typeof level === "number") {
-    return LEGACY_LEVEL_TO_EIKEN_LEVEL[level] ?? null;
-  }
-
-  return null;
-}
-
-function normalizeQuestionType(type: unknown): Settings["questionTypes"][number] | null {
-  if (typeof type !== "string") {
+function normalizeTag(tag: unknown): string | null {
+  if (typeof tag !== "string") {
     return null;
   }
 
-  const normalizedType = type.trim();
+  const normalizedTag = tag.trim().toLowerCase();
 
-  return AVAILABLE_QUESTION_TYPES.includes(
-    normalizedType as (typeof AVAILABLE_QUESTION_TYPES)[number]
-  )
-    ? (normalizedType as (typeof AVAILABLE_QUESTION_TYPES)[number])
-    : null;
+  return normalizedTag === "" ? null : normalizedTag;
 }
 
 function normalizeSettings(input: unknown): Settings {
-  const mergedSettings =
+  const source =
     typeof input === "object" && input !== null
-      ? { ...DEFAULT_SETTINGS, ...(input as Partial<Settings>) }
-      : DEFAULT_SETTINGS;
-  const eikenLevelsValue = (mergedSettings as Partial<Settings>).eikenLevels;
-  const legacyLevelsValue = (mergedSettings as { levels?: unknown[] }).levels;
-  const questionTypesValue = mergedSettings.questionTypes;
-  const sourceEikenLevels: unknown[] = Array.isArray(eikenLevelsValue)
-    ? [...eikenLevelsValue]
-    : Array.isArray(legacyLevelsValue)
-      ? [...legacyLevelsValue]
-      : [...DEFAULT_SETTINGS.eikenLevels];
-  const sourceQuestionTypes: unknown[] = Array.isArray(questionTypesValue)
-    ? [...questionTypesValue]
-    : [...DEFAULT_SETTINGS.questionTypes];
-  const normalizedEikenLevels = Array.from(
+      ? (input as Partial<Settings>)
+      : {};
+  const tagsValue = source.tags;
+  const sourceTags: unknown[] = Array.isArray(tagsValue)
+    ? [...tagsValue]
+    : [...DEFAULT_SETTINGS.tags];
+  const normalizedTags = Array.from(
     new Set(
-      sourceEikenLevels
-        .map((level) => normalizeEikenLevel(level))
-        .filter((level): level is Settings["eikenLevels"][number] => level !== null)
-    )
-  );
-  const normalizedQuestionTypes = Array.from(
-    new Set(
-      sourceQuestionTypes
-        .map((type) => normalizeQuestionType(type))
-        .filter((type): type is Settings["questionTypes"][number] => type !== null)
+      sourceTags.map((tag) => normalizeTag(tag)).filter((tag): tag is string => tag !== null)
     )
   );
 
   return {
     ...DEFAULT_SETTINGS,
-    eikenLevels:
-      normalizedEikenLevels.length > 0
-        ? normalizedEikenLevels
-        : [...DEFAULT_SETTINGS.eikenLevels],
-    questionTypes:
-      normalizedQuestionTypes.length > 0
-        ? normalizedQuestionTypes
-        : [...DEFAULT_SETTINGS.questionTypes]
+    tags: normalizedTags
   };
 }
 

--- a/frontend/src/shared/types/study.ts
+++ b/frontend/src/shared/types/study.ts
@@ -9,6 +9,7 @@ export type Question = {
   english: string;
   japanese: string;
   isActive: boolean;
+  tags: string[];
 };
 
 export type QuizProgress = {
@@ -42,6 +43,5 @@ export type DailySummary = {
 };
 
 export type Settings = {
-  eikenLevels: EikenLevel[];
-  questionTypes: QuizType[];
+  tags: string[];
 };


### PR DESCRIPTION
## 概要
- ホーム画面の学習開始条件を question type ではなくタグ選択ベースへ変更
- settings と localStorage を tags のみを持つ形へ整理し、未リリース前提で legacy 対応を削除
- 学習開始時の問題取得とセッション構築を tags フィルタへ統一

## 変更理由
- Issue #39 の方針どおり、固定 question type 選択ではなく自由タグ選択を学習導線に反映するため
- eiken ラベルもタグとして扱う方針に合わせて条件管理を単純化するため

## 検証
- npm test
- npm run lint
- npm run build

## 関連
- Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tag-based filtering system with dynamic tag selection UI on the home dashboard.
  * Integrated available tags fetched from the backend.

* **Refactor**
  * Replaced Eiken level and question type filtering with tag-based filtering throughout the study session and question browsing features.
  * Updated settings storage to persist and normalize tag preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->