### PR TITLE
fix: study result created_at を datetime として扱う

### DIFF
--- a/backend/alembic/versions/20260321_0001_initial_schema.py
+++ b/backend/alembic/versions/20260321_0001_initial_schema.py
@@ -47,7 +47,7 @@ def upgrade() -> None:
         sa.Column("correct_rate", sa.Integer(), nullable=False),
         sa.Column("mistakes", sa.Integer(), nullable=False),
         sa.Column("average_time", sa.Integer(), nullable=False),
-        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )  # 学習結果テーブルを作成する
 

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 
 
 @dataclass(frozen=True)
@@ -32,7 +33,7 @@ class RecordStudyResultCommand:
     correct_rate: int
     mistakes: int
     average_time: int
-    created_at: str
+    created_at: datetime
 
 
 @dataclass(frozen=True)
@@ -52,7 +53,7 @@ class StudyResultDto:
     correct_rate: int
     mistakes: int
     average_time: int
-    created_at: str
+    created_at: datetime
 
 
 @dataclass(frozen=True)

--- a/backend/application/tests/fakes.py
+++ b/backend/application/tests/fakes.py
@@ -1,5 +1,4 @@
-from backend.application.dtos import StudyResultDto
-from backend.domain.entities import DailyStudySummary, Question, QuestionType
+from backend.domain.entities import DailyStudySummary, Question, QuestionType, StudyResult
 
 
 class FakeQuestionRepository:
@@ -66,23 +65,23 @@ class FakeQuestionRepository:
 
 class FakeStudyResultRepository:
     def __init__(self) -> None:
-        self.saved_results: list[StudyResultDto] = []
+        self.saved_results: list[StudyResult] = []
 
-    def save(self, result: StudyResultDto) -> StudyResultDto:
+    def save(self, result: StudyResult) -> StudyResult:
         self.saved_results.append(result)  # 保存された結果をそのまま記録する
         return result
 
-    def get_latest(self) -> StudyResultDto | None:
+    def get_latest(self) -> StudyResult | None:
         return self.saved_results[-1] if self.saved_results else None  # 最後の要素を最新として返す
 
     def get_today_summary(self, target_date: str) -> DailyStudySummary:
         solved_problems = sum(
             result.total_questions
             for result in self.saved_results
-            if result.created_at.startswith(target_date)
+            if result.created_at.date().isoformat() == target_date
         )
         sessions = sum(
-            1 for result in self.saved_results if result.created_at.startswith(target_date)
+            1 for result in self.saved_results if result.created_at.date().isoformat() == target_date
         )
         return DailyStudySummary(
             date=target_date,

--- a/backend/application/tests/test_study_result_usecases.py
+++ b/backend/application/tests/test_study_result_usecases.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from backend.application.dtos import DailyStudySummaryDto, RecordStudyResultCommand, StudyResultDto
 from backend.application.usecases import get_latest_study_result, get_today_study_summary, record_study_result
 from backend.domain.entities import StudyMode
@@ -6,13 +8,14 @@ from backend.application.tests.fakes import FakeStudyResultRepository
 
 def test_study_result_use_cases_record_and_summarize_results() -> None:
     repository = FakeStudyResultRepository()
+    created_at = datetime(2026, 3, 21, 17, 0, tzinfo=timezone(timedelta(hours=9)))
     command = RecordStudyResultCommand(
         mode="learn",
         total_questions=10,
         correct_rate=90,
         mistakes=1,
         average_time=1200,
-        created_at="2026-03-21T08:00:00+00:00",
+        created_at=created_at,
     )
 
     saved = record_study_result(repository, command)
@@ -24,7 +27,7 @@ def test_study_result_use_cases_record_and_summarize_results() -> None:
         correct_rate=90,
         mistakes=1,
         average_time=1200,
-        created_at="2026-03-21T08:00:00+00:00",
+        created_at=datetime(2026, 3, 21, 8, 0, tzinfo=timezone.utc),
     )
     assert summary == DailyStudySummaryDto(
         date="2026-03-21",

--- a/backend/application/usecases.py
+++ b/backend/application/usecases.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from backend.application.dtos import (
     CreateQuestionCommand,
     DailyStudySummaryDto,
@@ -10,6 +12,13 @@ from backend.application.dtos import (
 from backend.domain.entities import DailyStudySummary, Question, QuestionType, StudyMode, StudyResult
 from backend.domain.repositories import QuestionRepository, StudyResultRepository
 from backend.domain.tag_rules import normalize_tags
+
+
+def _normalize_created_at(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)  # タイムゾーン未指定は UTC として扱う
+
+    return value.astimezone(timezone.utc)  # 内部では UTC に正規化して扱う
 
 
 def _parse_question_types(codes: list[str] | None) -> list[QuestionType] | None:
@@ -114,6 +123,7 @@ def record_study_result(
     repository: StudyResultRepository,
     command: RecordStudyResultCommand,
 ) -> StudyResultDto:
+    normalized_created_at = _normalize_created_at(command.created_at)
     saved_result = repository.save(
         StudyResult(
             mode=StudyMode(command.mode),
@@ -121,7 +131,7 @@ def record_study_result(
             correct_rate=command.correct_rate,
             mistakes=command.mistakes,
             average_time=command.average_time,
-            created_at=command.created_at,
+            created_at=normalized_created_at,
         )
     )
     return _to_study_result_dto(saved_result)  # 保存結果を返す

--- a/backend/domain/entities.py
+++ b/backend/domain/entities.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 
 
@@ -29,7 +30,7 @@ class StudyResult:
     correct_rate: int
     mistakes: int
     average_time: int
-    created_at: str
+    created_at: datetime
 
 
 @dataclass(frozen=True)

--- a/backend/infrastructure/sqlmodel/models.py
+++ b/backend/infrastructure/sqlmodel/models.py
@@ -57,4 +57,4 @@ class StudyResultRecord(SQLModel, table=True):
     correct_rate: int
     mistakes: int
     average_time: int
-    created_at: str
+    created_at: datetime

--- a/backend/infrastructure/sqlmodel/repositories.py
+++ b/backend/infrastructure/sqlmodel/repositories.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
 
 from sqlalchemy import delete, func
 from sqlalchemy.exc import IntegrityError
@@ -215,6 +215,12 @@ class SqlModelStudyResultRepository:
     def __init__(self, database_url: str) -> None:
         self.database_url = database_url
 
+    def _normalize_created_at(self, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=timezone.utc)  # タイムゾーン未指定は UTC として扱う
+
+        return value.astimezone(timezone.utc)  # 永続化前に UTC へ正規化する
+
     def _build_study_result(self, record: StudyResultRecord) -> StudyResult:
         return StudyResult(
             mode=StudyMode(record.mode.value),
@@ -222,10 +228,11 @@ class SqlModelStudyResultRepository:
             correct_rate=record.correct_rate,
             mistakes=record.mistakes,
             average_time=record.average_time,
-            created_at=record.created_at,
+            created_at=self._normalize_created_at(record.created_at),
         )  # ORM レコードをドメインエンティティへ変換する
 
     def save(self, result: StudyResult) -> StudyResult:
+        normalized_created_at = self._normalize_created_at(result.created_at)
         with get_session(self.database_url) as session:
             record = StudyResultRecord(
                 mode=StudyModeRecord(result.mode.value),
@@ -233,7 +240,7 @@ class SqlModelStudyResultRepository:
                 correct_rate=result.correct_rate,
                 mistakes=result.mistakes,
                 average_time=result.average_time,
-                created_at=result.created_at,
+                created_at=normalized_created_at,
             )
             session.add(record)
             session.commit()
@@ -252,12 +259,19 @@ class SqlModelStudyResultRepository:
         return self._build_study_result(latest_result) if latest_result is not None else None  # 最新結果があれば返す
 
     def get_today_summary(self, target_date: str) -> DailyStudySummary:
+        parsed_date = date.fromisoformat(target_date)
+        start_of_day = datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+        end_of_day = start_of_day + timedelta(days=1)
+
         with get_session(self.database_url) as session:
             sessions, solved_problems = session.exec(
                 select(
                     func.count(StudyResultRecord.id),
                     func.coalesce(func.sum(StudyResultRecord.total_questions), 0),
-                ).where(StudyResultRecord.created_at.startswith(target_date))
+                ).where(
+                    StudyResultRecord.created_at >= start_of_day,
+                    StudyResultRecord.created_at < end_of_day,
+                )
             ).one()
 
         return DailyStudySummary(

--- a/backend/infrastructure/sqlmodel/tests/test_bootstrap.py
+++ b/backend/infrastructure/sqlmodel/tests/test_bootstrap.py
@@ -116,7 +116,7 @@ def test_bootstrap_database_backfills_legacy_question_type_tags(tmp_path) -> Non
             correct_rate INTEGER NOT NULL,
             mistakes INTEGER NOT NULL,
             average_time INTEGER NOT NULL,
-            created_at TEXT NOT NULL
+            created_at DATETIME NOT NULL
         )
         """
     )
@@ -128,8 +128,8 @@ def test_bootstrap_database_backfills_legacy_question_type_tags(tmp_path) -> Non
             english_text TEXT NOT NULL,
             japanese_text TEXT NOT NULL,
             is_active BOOLEAN NOT NULL DEFAULT 1,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
             FOREIGN KEY(question_type_id) REFERENCES question_types(id)
         )
         """

--- a/backend/infrastructure/sqlmodel/tests/test_study_result_repository.py
+++ b/backend/infrastructure/sqlmodel/tests/test_study_result_repository.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta, timezone
+
+from backend.database import migrate_database
+from backend.domain.entities import StudyMode, StudyResult
+from backend.infrastructure.sqlmodel.repositories import SqlModelStudyResultRepository
+
+
+def test_get_latest_returns_latest_record_by_datetime(tmp_path) -> None:
+    database_url = f"sqlite:///{tmp_path / 'study-results-latest.db'}"
+    repository = SqlModelStudyResultRepository(database_url)
+    migrate_database(database_url)  # テスト用 DB に最新 schema を適用する
+    repository.save(
+        StudyResult(
+            mode=StudyMode.LEARN,
+            total_questions=5,
+            correct_rate=80,
+            mistakes=1,
+            average_time=1200,
+            created_at=datetime(2026, 3, 21, 23, 30, tzinfo=timezone(timedelta(hours=9))),
+        )
+    )
+    later_result = StudyResult(
+        mode=StudyMode.REVIEW,
+        total_questions=8,
+        correct_rate=90,
+        mistakes=0,
+        average_time=900,
+        created_at=datetime(2026, 3, 21, 15, 0, tzinfo=timezone.utc),
+    )
+    repository.save(later_result)
+
+    latest = repository.get_latest()
+
+    assert latest == StudyResult(
+        mode=StudyMode.REVIEW,
+        total_questions=8,
+        correct_rate=90,
+        mistakes=0,
+        average_time=900,
+        created_at=datetime(2026, 3, 21, 15, 0, tzinfo=timezone.utc),
+    )  # 文字列順ではなく正しい日時順で最新 1 件が返ることを確認する
+
+
+def test_get_today_summary_aggregates_records_by_utc_day(tmp_path) -> None:
+    database_url = f"sqlite:///{tmp_path / 'study-results-summary.db'}"
+    repository = SqlModelStudyResultRepository(database_url)
+    migrate_database(database_url)  # テスト用 DB に最新 schema を適用する
+    repository.save(
+        StudyResult(
+            mode=StudyMode.LEARN,
+            total_questions=4,
+            correct_rate=75,
+            mistakes=1,
+            average_time=1100,
+            created_at=datetime(2026, 3, 22, 0, 30, tzinfo=timezone(timedelta(hours=9))),
+        )
+    )
+    repository.save(
+        StudyResult(
+            mode=StudyMode.REVIEW,
+            total_questions=6,
+            correct_rate=100,
+            mistakes=0,
+            average_time=900,
+            created_at=datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    summary = repository.get_today_summary("2026-03-21")
+
+    assert summary.sessions == 2
+    assert summary.solved_problems == 10  # UTC 日付境界で集計し、文字列の prefix に依存しないことを確認する

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -527,6 +527,7 @@
           },
           "created_at": {
             "type": "string",
+            "format": "date-time",
             "title": "Created At"
           }
         },

--- a/backend/presentation/schemas.py
+++ b/backend/presentation/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -80,13 +80,15 @@ class StudyResultRequest(BaseModel):
     correct_rate: int = Field(ge=0, le=100)
     mistakes: int = Field(ge=0)
     average_time: int = Field(ge=0)
-    created_at: str
+    created_at: datetime
 
     @field_validator("created_at")
     @classmethod
-    def validate_created_at(cls, value: str) -> str:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))  # ISO 形式のみ許可する
-        return value
+    def validate_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=timezone.utc)  # タイムゾーン未指定は UTC として扱う
+
+        return value.astimezone(timezone.utc)  # 内部では UTC に正規化して扱う
 
 
 class DailyStudySummaryResponse(BaseModel):

--- a/backend/presentation/tests/test_openapi.py
+++ b/backend/presentation/tests/test_openapi.py
@@ -7,6 +7,7 @@ def test_build_openapi_schema_includes_core_metadata() -> None:
     schema = build_openapi_schema()
     question_parameters = schema["paths"]["/questions"]["get"].get("parameters", [])
     question_response_properties = schema["components"]["schemas"]["QuestionResponse"]["properties"]
+    study_result_properties = schema["components"]["schemas"]["StudyResultRequest"]["properties"]
 
     assert schema["openapi"].startswith("3.")  # OpenAPI 3 系で出力されることを確認する
     assert schema["info"]["title"] == "Typing App API"  # 既存 API タイトルが spec に反映されることを確認する
@@ -14,6 +15,7 @@ def test_build_openapi_schema_includes_core_metadata() -> None:
     assert "/study-results" in schema["paths"]  # POST エンドポイントも含まれることを確認する
     assert all(parameter["name"] != "eiken_levels" for parameter in question_parameters)  # 一覧 query から英検級フィルタが除去されることを確認する
     assert "eikenLevel" not in question_response_properties  # レスポンス契約から英検級が除去されることを確認する
+    assert study_result_properties["created_at"]["format"] == "date-time"  # StudyResult の日時項目が OpenAPI 上も date-time として公開されることを確認する
 
 
 def test_write_openapi_schema_persists_json_file(tmp_path) -> None:

--- a/backend/presentation/tests/test_study_results_api.py
+++ b/backend/presentation/tests/test_study_results_api.py
@@ -2,24 +2,31 @@ from datetime import datetime, timezone
 
 
 def test_post_study_result_persists_payload(client) -> None:
+    created_at = "2026-03-21T17:00:00+09:00"
     payload = {
         "mode": "learn",
         "total_questions": 10,
         "correct_rate": 80,
         "mistakes": 3,
         "average_time": 1200,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": created_at,
     }
 
     response = client.post("/study-results", json=payload)
 
     assert response.status_code == 201
-    assert response.json() == payload
+    assert response.json() == {
+        **payload,
+        "created_at": "2026-03-21T08:00:00Z",
+    }  # API 境界では ISO 文字列を受け取りつつ、内部 datetime を UTC の ISO 文字列で返すことを確認する
 
     latest_response = client.get("/study-results/latest")
 
     assert latest_response.status_code == 200
-    assert latest_response.json() == payload
+    assert latest_response.json() == {
+        **payload,
+        "created_at": "2026-03-21T08:00:00Z",
+    }
 
 
 def test_post_study_result_rejects_invalid_payload(client) -> None:


### PR DESCRIPTION
## What
- study_results.created_at を application / domain / infrastructure で datetime に統一
- API 境界では ISO 8601 文字列を datetime に変換し、レスポンスは date-time 形式で返却
- 日次集計を文字列 prefix 依存から日時範囲条件へ変更
- study result repository の回帰テストと OpenAPI 更新を追加

## Why
- created_at が文字列のまま内部層まで流れており、型安全性と責務分離が崩れていたため
- 最新取得と日次集計が文字列ソートや startswith に依存していたため
- 未リリースのため初期 migration を datetime 前提へ揃え、DB を作り直しやすくするため

## Validation
- cd backend && uv run pytest

Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Study result timestamps now use timezone-aware datetime objects with automatic UTC normalization for consistent handling across different timezones.

* **Bug Fixes**
  * Improved date filtering accuracy by using UTC day boundaries instead of string-based matching for daily summaries.

* **Documentation**
  * Updated API schema specification to explicitly indicate date-time format for timestamp fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->