### PR TITLE
fix: move openapi spec into backend docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ build:
 	cd frontend && npm run build
 
 openapi:
-	uv run --project backend python -m backend.commands.export_openapi --output backend/openapi.json
+	uv run --project backend python -m backend.commands.export_openapi --output backend/docs/openapi.json

--- a/backend/commands/export_openapi.py
+++ b/backend/commands/export_openapi.py
@@ -3,14 +3,14 @@ import argparse
 from backend.presentation.openapi import write_openapi_schema
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="FastAPI の OpenAPI spec を JSON として出力します。")
     parser.add_argument(
         "--output",
-        default="backend/openapi.json",
+        default="backend/docs/openapi.json",
         help="出力先の JSON ファイルパス",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def main() -> None:

--- a/backend/commands/tests/test_export_openapi.py
+++ b/backend/commands/tests/test_export_openapi.py
@@ -1,0 +1,7 @@
+from backend.commands.export_openapi import parse_args
+
+
+def test_parse_args_defaults_output_to_backend_docs() -> None:
+    args = parse_args([])  # 引数未指定時の既定値を確認する
+
+    assert args.output == "backend/docs/openapi.json"  # OpenAPI spec の既定出力先を docs 配下へ固定する

--- a/backend/docs/openapi.json
+++ b/backend/docs/openapi.json
@@ -27,6 +27,24 @@
         }
       }
     },
+    "/tags": {
+      "get": {
+        "summary": "Get Tags",
+        "operationId": "get_tags_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/questions": {
       "get": {
         "summary": "Get Questions",
@@ -492,6 +510,22 @@
           "created_at"
         ],
         "title": "StudyResultRequest"
+      },
+      "TagListResponse": {
+        "properties": {
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags"
+        ],
+        "title": "TagListResponse"
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
## What changed
- moved the OpenAPI spec output path from `backend/openapi.json` to `backend/docs/openapi.json`
- updated the export command default and `make openapi` target to use the new path
- added a test to lock the CLI default output path

## Why it changed
- keep generated API documentation under `backend/docs/` with the rest of the backend docs
- avoid having direct CLI execution and Makefile output to different locations

## Validation performed
- `uv run --project backend pytest backend`
- `make openapi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `GET /tags` endpoint that retrieves a list of available tags in JSON format.

* **Tests**
  * Added test coverage for OpenAPI schema generation and export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->