### PR TITLE
feat: update typing app design document

### DIFF
--- a/frontend/docs/typing_app.pen
+++ b/frontend/docs/typing_app.pen
@@ -1,5 +1,5 @@
 {
-  "version": "2.9",
+  "version": "2.10",
   "children": [
     {
       "type": "frame",
@@ -10028,7 +10028,7 @@
               "width": 640,
               "name": "mainCard",
               "x": 320,
-              "y": 250.5,
+              "y": 208,
               "height": "fit_content",
               "descendants": {
                 "GAQvC": {
@@ -10075,29 +10075,94 @@
                   "name": "newContent",
                   "width": "fill_container",
                   "layout": "vertical",
-                  "padding": 24,
+                  "gap": 4,
+                  "padding": [
+                    16,
+                    24
+                  ],
                   "children": [
                     {
                       "type": "frame",
-                      "id": "1Q3VA",
-                      "name": "engBox",
+                      "id": "uU6BA",
+                      "name": "sentence1-completed",
                       "width": "fill_container",
-                      "fill": "$--muted",
                       "cornerRadius": 6,
-                      "layout": "vertical",
-                      "padding": 16,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
                       "children": [
                         {
                           "type": "text",
-                          "id": "2clyv",
-                          "name": "engText",
+                          "id": "weW8w",
+                          "name": "engText1",
+                          "fill": "$--muted-foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "I drink coffee every morning.",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oZbX5",
+                      "name": "sentence2-active",
+                      "width": "fill_container",
+                      "fill": "$--muted",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ACgEo",
+                          "name": "engText2",
                           "fill": "$--foreground",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
                           "content": "The train was delayed because of the rain.",
+                          "lineHeight": 1.6,
                           "fontFamily": "Inter",
-                          "fontSize": 16,
-                          "fontWeight": "500"
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LsLB9",
+                      "name": "sentence3-upcoming",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "q3Sur",
+                          "name": "engText3",
+                          "fill": "$--muted-foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Learning a language takes patience and repetition.",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "normal"
                         }
                       ]
                     }
@@ -10117,7 +10182,7 @@
               "width": 640,
               "name": "inputGroup",
               "x": 320,
-              "y": 479.5,
+              "y": 522,
               "height": "fit_content",
               "descendants": {
                 "reBfl": {
@@ -13382,6 +13447,3017 @@
                   }
                 }
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "1Je3Q",
+      "x": 3783,
+      "y": 3100,
+      "name": "shadcn - Long Text Session",
+      "width": 1280,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "58E7D",
+          "name": "topSection",
+          "width": "fill_container",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tIqyQ",
+              "name": "header",
+              "width": "fill_container",
+              "height": 56,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              },
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sxUNg",
+                  "name": "leftGroup",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "GJW7Q",
+                      "type": "ref",
+                      "ref": "GbCF2",
+                      "name": "badge1",
+                      "x": 0,
+                      "y": 18,
+                      "descendants": {
+                        "npWsI": {
+                          "content": "LONG TEXT"
+                        }
+                      }
+                    },
+                    {
+                      "id": "4voPz",
+                      "type": "ref",
+                      "ref": "2UowQ",
+                      "width": "fill_container",
+                      "height": 8,
+                      "name": "prog",
+                      "x": 101,
+                      "y": 24,
+                      "descendants": {
+                        "71A7i": {
+                          "width": 90,
+                          "height": 8
+                        }
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "id": "J7pgx",
+                      "name": "counter",
+                      "fill": "$--muted-foreground",
+                      "content": "256 / 1,024 字",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "id": "ZsfNo",
+                  "type": "ref",
+                  "ref": "GbCF2",
+                  "name": "timerBadge",
+                  "x": 1197,
+                  "y": 18,
+                  "descendants": {
+                    "npWsI": {
+                      "content": "03:45"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bMZES",
+              "name": "textPanel",
+              "width": "fill_container",
+              "layout": "vertical",
+              "padding": [
+                24,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "RMJqY",
+                  "type": "ref",
+                  "ref": "Go7j1",
+                  "width": 960,
+                  "padding": 24,
+                  "gap": 12,
+                  "name": "card",
+                  "height": "fit_content",
+                  "x": 160,
+                  "y": 24,
+                  "descendants": {
+                    "GAQvC": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 24,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "id": "FosRw",
+                          "type": "ref",
+                          "ref": "B7kcV",
+                          "name": "passageBadge",
+                          "x": 0,
+                          "y": 0,
+                          "descendants": {
+                            "VBuxq": {
+                              "content": "passage"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "p3EMx": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 56,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3E992",
+                          "name": "jpText",
+                          "fill": "$--foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "日本の四季は、それぞれに独特の美しさと文化的な意味を持っています。春には桜が咲き誇り、多くの人々が花見を楽しみます。夏は祭りや花火大会で賑わい、秋には紅葉が山々を彩ります。冬は静寂の中にも温泉や鍋料理など、心を温める楽しみがあります。",
+                          "lineHeight": 1.8,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    "3rBJ1": {
+                      "width": "fill_container(912)",
+                      "x": 24,
+                      "y": 48,
+                      "enabled": false
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "cpvox",
+          "name": "bottomSection",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yLgSo",
+              "name": "typingDisplayCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Jrewo",
+                  "name": "typingCardHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "GE5KH",
+                      "name": "typingLabel",
+                      "fill": "$--foreground",
+                      "content": "英文を入力",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "I9z1Q",
+                      "name": "typingHint",
+                      "fill": "$--muted-foreground",
+                      "content": "入力中のテキストがハイライトされます",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CmmWb",
+                  "name": "typingCardBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "jLmxk",
+                      "name": "referenceText",
+                      "fill": "$--muted-foreground",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Japan's four seasons each have their own unique beauty and cultural significance. In spring, cherry blossoms bloom and many people enjoy hanami. Summer is lively with festivals and fireworks, and in autumn, the autumn leaves color the mountains. Winter, despite its tranquility, offers warm pleasures such as hot springs and hot pot dishes.",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LIOl4",
+                      "name": "cursorIndicator",
+                      "width": "fill_container",
+                      "gap": 4,
+                      "padding": [
+                        8,
+                        0,
+                        0,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "jMSW6",
+                          "name": "cursorIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "text-cursor-input",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "bczp1",
+                          "name": "cursorPosition",
+                          "fill": "$--muted-foreground",
+                          "content": "カーソル位置: 112 / 338文字",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "pQQqf",
+                      "layoutPosition": "absolute",
+                      "x": 24,
+                      "y": 24,
+                      "name": "typedOverlay",
+                      "fill": "$--foreground",
+                      "textGrowth": "fixed-width",
+                      "width": 912,
+                      "content": "Japan's four seasons each have their own unique beauty and cultural significance. In spring, cherry blossoms bloom ",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "gafyE",
+              "type": "ref",
+              "ref": "J1Vp9",
+              "name": "longTextInput",
+              "width": 960,
+              "x": 160,
+              "y": 332.5,
+              "descendants": {
+                "5a82H": {
+                  "width": "fill_container(960)",
+                  "enabled": false
+                },
+                "n04ol": {
+                  "width": "fill_container"
+                },
+                "IoqZn": {
+                  "width": "fill_container",
+                  "height": 120
+                },
+                "jxR8X": {
+                  "content": "ここに英文を入力してください...",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "lineHeight": 1.8
+                }
+              }
+            },
+            {
+              "type": "frame",
+              "id": "tYcYn",
+              "name": "statsBar",
+              "width": 960,
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "isdCX",
+                  "name": "statWpm",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "NAiWT",
+                      "name": "stat1Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "gauge",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iN3sH",
+                      "name": "stat1Text",
+                      "fill": "$--muted-foreground",
+                      "content": "42 WPM",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CTsgN",
+                  "name": "statAccuracy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "TiuWt",
+                      "name": "stat2Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "target",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "B9rTG",
+                      "name": "stat2Text",
+                      "fill": "$--muted-foreground",
+                      "content": "正確率 94.2%",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JXyEo",
+                  "name": "statChars",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "m75g2",
+                      "name": "stat3Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "type",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "1Dt14",
+                      "name": "stat3Text",
+                      "fill": "$--muted-foreground",
+                      "content": "112 / 338 文字",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "M3E2e",
+                  "name": "statMiss",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Dw9LN",
+                      "name": "stat4Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "circle-x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--destructive"
+                    },
+                    {
+                      "type": "text",
+                      "id": "6hrE7",
+                      "name": "stat4Text",
+                      "fill": "$--muted-foreground",
+                      "content": "ミス 3回",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Jb8d6",
+          "name": "footer",
+          "width": "fill_container",
+          "height": 48,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "BZbXa",
+              "name": "footerLeft",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "P74Pw",
+                  "name": "escIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "corner-down-left",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "Rlszi",
+                  "name": "escText",
+                  "fill": "$--muted-foreground",
+                  "content": "Enter で改行",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "NULvI",
+                  "name": "tabIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "move-horizontal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "auvmv",
+                  "name": "tabText",
+                  "fill": "$--muted-foreground",
+                  "content": "Tab でスキップ",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "gbLvs",
+              "name": "footerHint",
+              "fill": "$--muted-foreground",
+              "content": "スペースと大文字小文字も判定対象です。",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "ym3k5",
+              "name": "homeLink",
+              "fill": "$--muted-foreground",
+              "content": "中断してホームへ戻る",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "iRBYG",
+      "x": 3783,
+      "y": 4120,
+      "name": "shadcn - Unified Session (Short)",
+      "width": 1280,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Yhwq8",
+          "name": "topSection",
+          "width": "fill_container",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "gUVry",
+              "name": "header",
+              "width": "fill_container",
+              "height": 56,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              },
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UjS9F",
+                  "name": "leftGroup",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "DjZE1",
+                      "type": "ref",
+                      "ref": "GbCF2",
+                      "name": "badge1",
+                      "x": 0,
+                      "y": 18,
+                      "descendants": {
+                        "npWsI": {
+                          "content": "LEARN MODE"
+                        }
+                      }
+                    },
+                    {
+                      "id": "KmQB6",
+                      "type": "ref",
+                      "ref": "2UowQ",
+                      "width": "fill_container",
+                      "height": 8,
+                      "name": "prog",
+                      "x": 111,
+                      "y": 24,
+                      "descendants": {
+                        "71A7i": {
+                          "width": 40,
+                          "height": 8
+                        }
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "id": "3sdDH",
+                      "name": "counter",
+                      "fill": "$--muted-foreground",
+                      "content": "1 / 10",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "id": "HyNvL",
+                  "type": "ref",
+                  "ref": "GbCF2",
+                  "name": "timerBadge",
+                  "x": 1197,
+                  "y": 18,
+                  "descendants": {
+                    "npWsI": {
+                      "content": "00:32"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "h9wnW",
+              "name": "textPanel",
+              "width": "fill_container",
+              "layout": "vertical",
+              "padding": [
+                24,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "HbU80",
+                  "type": "ref",
+                  "ref": "Go7j1",
+                  "width": 960,
+                  "padding": 24,
+                  "gap": 12,
+                  "name": "card",
+                  "height": "fit_content",
+                  "x": 160,
+                  "y": 24,
+                  "descendants": {
+                    "GAQvC": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 24,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "id": "JbtaJ",
+                          "type": "ref",
+                          "ref": "B7kcV",
+                          "name": "passageBadge",
+                          "x": 0,
+                          "y": 0,
+                          "descendants": {
+                            "VBuxq": {
+                              "content": "sentence"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "p3EMx": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 56,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ppagl",
+                          "name": "jpText",
+                          "fill": "$--foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "雨のため電車が遅れました。",
+                          "lineHeight": 1.8,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    "3rBJ1": {
+                      "width": "fill_container(912)",
+                      "x": 24,
+                      "y": 48,
+                      "enabled": false
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WmmqY",
+          "name": "bottomSection",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "FS1mI",
+              "name": "typingDisplayCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0MpNc",
+                  "name": "typingCardHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "8qTH2",
+                      "name": "typingLabel",
+                      "fill": "$--foreground",
+                      "content": "英文を入力",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "9kQwx",
+                      "name": "typingHint",
+                      "fill": "$--muted-foreground",
+                      "content": "入力中のテキストがハイライトされます",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HFDMu",
+                  "name": "typingCardBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QU1b7",
+                      "name": "referenceText",
+                      "fill": "$--muted-foreground",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "The train was delayed because of the rain.",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "3jPaw",
+                      "name": "cursorIndicator",
+                      "width": "fill_container",
+                      "gap": 4,
+                      "padding": [
+                        8,
+                        0,
+                        0,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Mssvr",
+                          "name": "cursorIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "text-cursor-input",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HGIqy",
+                          "name": "cursorPosition",
+                          "fill": "$--muted-foreground",
+                          "content": "カーソル位置: 21 / 43文字",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "8BXlO",
+                      "layoutPosition": "absolute",
+                      "x": 24,
+                      "y": 24,
+                      "name": "typedOverlay",
+                      "fill": "$--foreground",
+                      "textGrowth": "fixed-width",
+                      "width": 912,
+                      "content": "The train was delayed ",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "xEu5Z",
+              "type": "ref",
+              "ref": "J1Vp9",
+              "name": "longTextInput",
+              "width": 960,
+              "x": 160,
+              "y": 363.5,
+              "descendants": {
+                "5a82H": {
+                  "width": "fill_container(960)",
+                  "enabled": false
+                },
+                "n04ol": {
+                  "width": "fill_container"
+                },
+                "IoqZn": {
+                  "width": "fill_container",
+                  "height": 56
+                },
+                "jxR8X": {
+                  "content": "ここに英文を入力してください...",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "lineHeight": 1.8
+                }
+              }
+            },
+            {
+              "type": "frame",
+              "id": "zmg8A",
+              "name": "statsBar",
+              "width": 960,
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5rrPd",
+                  "name": "statWpm",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "eXN10",
+                      "name": "stat1Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "gauge",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mbASQ",
+                      "name": "stat1Text",
+                      "fill": "$--muted-foreground",
+                      "content": "38 WPM",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zuBHs",
+                  "name": "statAccuracy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "12qJw",
+                      "name": "stat2Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "target",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VCjAw",
+                      "name": "stat2Text",
+                      "fill": "$--muted-foreground",
+                      "content": "正確率 94.2%",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mg8BX",
+                  "name": "statChars",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "yLXD7",
+                      "name": "stat3Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "type",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "f2fSu",
+                      "name": "stat3Text",
+                      "fill": "$--muted-foreground",
+                      "content": "21 / 43 文字",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xBRZp",
+                  "name": "statMiss",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0xkM1",
+                      "name": "stat4Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "circle-x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--destructive"
+                    },
+                    {
+                      "type": "text",
+                      "id": "7mA7H",
+                      "name": "stat4Text",
+                      "fill": "$--muted-foreground",
+                      "content": "ミス 0回",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "EpKY0",
+          "name": "footer",
+          "width": "fill_container",
+          "height": 48,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "s28CK",
+              "name": "footerLeft",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "OCV9g",
+                  "name": "escIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "corner-down-left",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "kDjEK",
+                  "name": "escText",
+                  "fill": "$--muted-foreground",
+                  "content": "Enter で改行",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "C5vFn",
+                  "name": "tabIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "move-horizontal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "WXuM0",
+                  "name": "tabText",
+                  "fill": "$--muted-foreground",
+                  "content": "Tab でスキップ",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "esAA4",
+              "name": "footerHint",
+              "fill": "$--muted-foreground",
+              "content": "スペースと大文字小文字も判定対象です。",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "WQun4",
+              "name": "homeLink",
+              "fill": "$--muted-foreground",
+              "content": "中断してホームへ戻る",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "D5Zxu",
+      "x": 5183,
+      "y": 4120,
+      "name": "shadcn - Unified Session (Long)",
+      "width": 1280,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "nE4LW",
+          "name": "topSection",
+          "width": "fill_container",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "LxO3y",
+              "name": "header",
+              "width": "fill_container",
+              "height": 56,
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "$--border"
+              },
+              "padding": [
+                0,
+                32
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q3ZOz",
+                  "name": "leftGroup",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "a3BsX",
+                      "type": "ref",
+                      "ref": "GbCF2",
+                      "name": "badge1",
+                      "x": 0,
+                      "y": 18,
+                      "descendants": {
+                        "npWsI": {
+                          "content": "LEARN MODE"
+                        }
+                      }
+                    },
+                    {
+                      "id": "1izVK",
+                      "type": "ref",
+                      "ref": "2UowQ",
+                      "width": "fill_container",
+                      "height": 8,
+                      "name": "prog",
+                      "x": 111,
+                      "y": 24,
+                      "descendants": {
+                        "71A7i": {
+                          "width": 120,
+                          "height": 8
+                        }
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "id": "gz7WU",
+                      "name": "counter",
+                      "fill": "$--muted-foreground",
+                      "content": "3 / 10",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "id": "rRCsT",
+                  "type": "ref",
+                  "ref": "GbCF2",
+                  "name": "timerBadge",
+                  "x": 1197,
+                  "y": 18,
+                  "descendants": {
+                    "npWsI": {
+                      "content": "03:45"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qURVN",
+              "name": "textPanel",
+              "width": "fill_container",
+              "layout": "vertical",
+              "padding": [
+                24,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "kzfVe",
+                  "type": "ref",
+                  "ref": "Go7j1",
+                  "width": 960,
+                  "padding": 24,
+                  "gap": 12,
+                  "name": "card",
+                  "height": "fit_content",
+                  "x": 160,
+                  "y": 24,
+                  "descendants": {
+                    "GAQvC": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 24,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "id": "VbeR2",
+                          "type": "ref",
+                          "ref": "B7kcV",
+                          "name": "passageBadge",
+                          "x": 0,
+                          "y": 0,
+                          "descendants": {
+                            "VBuxq": {
+                              "content": "passage"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "p3EMx": {
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 56,
+                      "padding": 0,
+                      "height": "fit_content",
+                      "gap": 0,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jG4PT",
+                          "name": "jpText",
+                          "fill": "$--foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "日本の四季は、それぞれに独特の美しさと文化的な意味を持っています。春には桜が咲き誇り、多くの人々が花見を楽しみます。夏は祭りや花火大会で賑わい、秋には紅葉が山々を彩ります。冬は静寂の中にも温泉や鍋料理など、心を温める楽しみがあります。",
+                          "lineHeight": 1.8,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    "3rBJ1": {
+                      "width": "fill_container(912)",
+                      "x": 24,
+                      "y": 48,
+                      "enabled": false
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "o3PmM",
+          "name": "bottomSection",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "13tGs",
+              "name": "typingDisplayCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T5rcn",
+                  "name": "typingCardHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tZj78",
+                      "name": "typingLabel",
+                      "fill": "$--foreground",
+                      "content": "英文を入力",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zw23f",
+                      "name": "typingHint",
+                      "fill": "$--muted-foreground",
+                      "content": "入力中のテキストがハイライトされます",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "plCdg",
+                  "name": "typingCardBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DRcIJ",
+                      "name": "referenceText",
+                      "fill": "$--muted-foreground",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Japan's four seasons each have their own unique beauty and cultural significance. In spring, cherry blossoms bloom and many people enjoy hanami. Summer is lively with festivals and fireworks, and in autumn, the autumn leaves color the mountains. Winter, despite its tranquility, offers warm pleasures such as hot springs and hot pot dishes.",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vPv9G",
+                      "name": "cursorIndicator",
+                      "width": "fill_container",
+                      "gap": 4,
+                      "padding": [
+                        8,
+                        0,
+                        0,
+                        0
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "W71Gf",
+                          "name": "cursorIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "text-cursor-input",
+                          "iconFontFamily": "lucide",
+                          "fill": "$--primary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DYJum",
+                          "name": "cursorPosition",
+                          "fill": "$--muted-foreground",
+                          "content": "カーソル位置: 112 / 338文字",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "o2F3N",
+                      "layoutPosition": "absolute",
+                      "x": 24,
+                      "y": 24,
+                      "name": "typedOverlay",
+                      "fill": "$--foreground",
+                      "textGrowth": "fixed-width",
+                      "width": 912,
+                      "content": "Japan's four seasons each have their own unique beauty and cultural significance. In spring, cherry blossoms bloom ",
+                      "lineHeight": 2,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "HKetM",
+              "type": "ref",
+              "ref": "J1Vp9",
+              "name": "longTextInput",
+              "width": 960,
+              "x": 160,
+              "y": 332.5,
+              "descendants": {
+                "5a82H": {
+                  "width": "fill_container(960)",
+                  "enabled": false
+                },
+                "n04ol": {
+                  "width": "fill_container"
+                },
+                "IoqZn": {
+                  "width": "fill_container",
+                  "height": 120
+                },
+                "jxR8X": {
+                  "content": "Japan's four seasons each have their own unique beauty and cultural significance. In spring, cherry blossoms bloom ",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "lineHeight": 1.8
+                }
+              }
+            },
+            {
+              "type": "frame",
+              "id": "P6aC0",
+              "name": "statsBar",
+              "width": 960,
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "7TPvh",
+                  "name": "statWpm",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "4HeHU",
+                      "name": "stat1Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "gauge",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "MjbRG",
+                      "name": "stat1Text",
+                      "fill": "$--muted-foreground",
+                      "content": "42 WPM",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CwGvF",
+                  "name": "statAccuracy",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hS1iF",
+                      "name": "stat2Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "target",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "0x2eu",
+                      "name": "stat2Text",
+                      "fill": "$--muted-foreground",
+                      "content": "正確率 94.2%",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c5reh",
+                  "name": "statChars",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "24ZdX",
+                      "name": "stat3Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "type",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "6PZvZ",
+                      "name": "stat3Text",
+                      "fill": "$--muted-foreground",
+                      "content": "112 / 338 文字",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UbFUn",
+                  "name": "statMiss",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ehS85",
+                      "name": "stat4Icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "circle-x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--destructive"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JmjT0",
+                      "name": "stat4Text",
+                      "fill": "$--muted-foreground",
+                      "content": "ミス 3回",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oTEEX",
+          "name": "footer",
+          "width": "fill_container",
+          "height": 48,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yMPKf",
+              "name": "footerLeft",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "8cvdt",
+                  "name": "escIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "corner-down-left",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "zEPK2",
+                  "name": "escText",
+                  "fill": "$--muted-foreground",
+                  "content": "Enter で改行",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "cLxIc",
+                  "name": "tabIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "move-horizontal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "f29m9",
+                  "name": "tabText",
+                  "fill": "$--muted-foreground",
+                  "content": "Tab でスキップ",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "RjuqV",
+              "name": "footerHint",
+              "fill": "$--muted-foreground",
+              "content": "スペースと大文字小文字も判定対象です。",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "ND24M",
+              "name": "homeLink",
+              "fill": "$--muted-foreground",
+              "content": "中断してホームへ戻る",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "PGWXE",
+      "x": 3783,
+      "y": 5340,
+      "name": "shadcn - Session v2 (Short)",
+      "width": 1280,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "LvsIv",
+          "name": "header",
+          "width": "fill_container",
+          "height": 56,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "H8HS8",
+              "name": "headerLeft",
+              "width": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "5TjSx",
+                  "type": "ref",
+                  "ref": "GbCF2",
+                  "name": "badge1",
+                  "x": 0,
+                  "y": 0,
+                  "descendants": {
+                    "npWsI": {
+                      "content": "LEARN MODE"
+                    }
+                  }
+                },
+                {
+                  "id": "Ai3Du",
+                  "type": "ref",
+                  "ref": "2UowQ",
+                  "height": 8,
+                  "name": "prog",
+                  "width": "fill_container",
+                  "x": 107,
+                  "y": 6,
+                  "descendants": {
+                    "71A7i": {
+                      "width": 40,
+                      "height": 8
+                    }
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "l7SPo",
+                  "name": "pageText",
+                  "fill": "$--muted-foreground",
+                  "content": "1 / 10",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "id": "YPo7N",
+              "type": "ref",
+              "ref": "GbCF2",
+              "name": "timerBadge",
+              "x": 1197,
+              "y": 18,
+              "descendants": {
+                "npWsI": {
+                  "content": "00:32"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "n1f6Z",
+          "name": "main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "RIkZt",
+              "name": "srcCard",
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cmv3Q",
+                  "name": "srcHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "dhSjT",
+                      "type": "ref",
+                      "ref": "B7kcV",
+                      "name": "sentBadge",
+                      "x": 24,
+                      "y": 12,
+                      "descendants": {
+                        "VBuxq": {
+                          "content": "sentence"
+                        }
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "id": "Iz3nx",
+                      "name": "srcCount",
+                      "fill": "$--muted-foreground",
+                      "content": "文 1 / 1",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Wtk7O",
+                  "name": "srcBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wHIOT",
+                      "name": "sentRow",
+                      "width": "fill_container",
+                      "fill": "$--muted",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YtN9T",
+                          "name": "sentText",
+                          "fill": "$--foreground",
+                          "content": "雨のため電車が遅れました。",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yRHuf",
+              "name": "typCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Foq1x",
+                  "name": "typHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JNyCw",
+                      "name": "typLeft",
+                      "fill": "$--foreground",
+                      "content": "英文を入力",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AKNWl",
+                      "name": "typRight",
+                      "fill": "$--muted-foreground",
+                      "content": "入力中のテキストがハイライトされます",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4x5PY",
+                  "name": "typBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "9cTJ6",
+                      "name": "engRef",
+                      "fill": "$--foreground",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "The train was delayed because of the rain.",
+                      "lineHeight": 1.8,
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "id": "Dej80",
+                      "type": "ref",
+                      "ref": "bvrBh",
+                      "width": "fill_container",
+                      "name": "inputGrp",
+                      "x": 24,
+                      "y": 67,
+                      "descendants": {
+                        "reBfl": {
+                          "width": "fill_container",
+                          "height": "fit_content"
+                        },
+                        "mjoFC": {
+                          "width": "fill_container",
+                          "content": "英語を入力"
+                        },
+                        "6t91O": {
+                          "width": "fill_container",
+                          "height": "fit_content"
+                        },
+                        "H6b8U": {
+                          "content": "ここに入力してください"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oSwy2",
+              "name": "statsBar",
+              "width": 960,
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "6FEWf",
+                  "name": "stat1",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "bWWra",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "gauge",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QC559",
+                      "fill": "$--muted-foreground",
+                      "content": "38 WPM",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FBeeo",
+                  "name": "stat2",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "tOvFv",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "target",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qrCTA",
+                      "fill": "$--muted-foreground",
+                      "content": "正確率 94.2%",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HyAjF",
+                  "name": "stat3",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hjTpu",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "type",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "e1JPV",
+                      "fill": "$--muted-foreground",
+                      "content": "21 / 43 文字",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yQCcr",
+                  "name": "stat4",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "S1pZT",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "circle-x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--destructive"
+                    },
+                    {
+                      "type": "text",
+                      "id": "eNjq8",
+                      "fill": "$--muted-foreground",
+                      "content": "ミス 0回",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "nFliZ",
+          "name": "footer",
+          "width": "fill_container",
+          "height": 48,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "EEqwg",
+              "name": "footLeft",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZUPEz",
+                  "name": "enterGrp",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5zia2",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "corner-down-left",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "lzbng",
+                      "fill": "$--muted-foreground",
+                      "content": "Enter で改行",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e0hQg",
+                  "name": "tabGrp",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "aaeDk",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "move-horizontal",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jCkLq",
+                      "fill": "$--muted-foreground",
+                      "content": "Tab でスキップ",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "EbObI",
+              "fill": "$--muted-foreground",
+              "content": "スペースと大文字小文字も判定対象です。",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "kQeJu",
+              "fill": "$--muted-foreground",
+              "content": "中断してホームへ戻る",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "owqp0",
+      "x": 5183,
+      "y": 5340,
+      "name": "shadcn - Session v2 (Long)",
+      "width": 1280,
+      "height": 900,
+      "fill": "$--background",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "H4QuI",
+          "name": "header",
+          "width": "fill_container",
+          "height": 56,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "zmMwl",
+              "name": "leftGroup",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "UQyAW",
+                  "type": "ref",
+                  "ref": "GbCF2",
+                  "name": "modeBadge",
+                  "x": 0,
+                  "y": 18,
+                  "descendants": {
+                    "npWsI": {
+                      "content": "LEARN MODE"
+                    }
+                  }
+                },
+                {
+                  "id": "PZqn9",
+                  "type": "ref",
+                  "ref": "2UowQ",
+                  "name": "progress",
+                  "width": "fill_container",
+                  "height": 8,
+                  "x": 111,
+                  "y": 24,
+                  "descendants": {
+                    "71A7i": {
+                      "height": 8,
+                      "width": 120
+                    }
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "Qqkhc",
+                  "name": "counter",
+                  "fill": "$--muted-foreground",
+                  "content": "3 / 10",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "id": "P9LmL",
+              "type": "ref",
+              "ref": "GbCF2",
+              "name": "timerBadge",
+              "x": 1197,
+              "y": 18,
+              "descendants": {
+                "npWsI": {
+                  "content": "03:45"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "zP1rl",
+          "name": "mainArea",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 20,
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "NXasV",
+              "name": "sourceTextCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "e5rLU",
+                  "name": "sourceCardHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "id": "C6laD",
+                      "type": "ref",
+                      "ref": "B7kcV",
+                      "name": "passageBadge",
+                      "x": 24,
+                      "y": 12,
+                      "descendants": {
+                        "VBuxq": {
+                          "content": "passage"
+                        }
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "id": "3qnaA",
+                      "name": "sentenceCounter",
+                      "fill": "$--muted-foreground",
+                      "content": "文 2 / 4",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "VoODJ",
+                  "name": "sourceCardBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "R1U2N",
+                      "name": "sentence1-completed",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "m9LhY",
+                          "name": "jpText1",
+                          "fill": "$--muted-foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "日本の四季は、それぞれに独特の美しさと文化的な意味を持っています。",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fW1x3",
+                      "name": "sentence2-active",
+                      "width": "fill_container",
+                      "fill": "$--muted",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ziGGX",
+                          "name": "jpText2",
+                          "fill": "$--foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "春には桜が咲き誇り、多くの人々が花見を楽しみます。",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "o4RYx",
+                      "name": "sentence3-upcoming",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "KRp0d",
+                          "name": "jpText3",
+                          "fill": "$--muted-foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "夏は祭りや花火大会で賑わい、秋には紅葉が山々を彩ります。",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "r2vHd",
+                      "name": "sentence4-upcoming",
+                      "width": "fill_container",
+                      "cornerRadius": 6,
+                      "gap": 12,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eufk8",
+                          "name": "jpText4",
+                          "fill": "$--muted-foreground",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "冬は静寂の中にも温泉や鍋料理など、心を温める楽しみがあります。",
+                          "lineHeight": 1.6,
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TSaph",
+              "name": "typingCard",
+              "clip": true,
+              "width": 960,
+              "fill": "$--card",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$--border"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BAHJX",
+                  "name": "typingCardHeader",
+                  "width": "fill_container",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$--border"
+                  },
+                  "padding": [
+                    16,
+                    24
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KueOQ",
+                      "name": "typingLabel",
+                      "fill": "$--foreground",
+                      "content": "英文を入力",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "X7h3C",
+                      "name": "typingHint",
+                      "fill": "$--muted-foreground",
+                      "content": "文 2 / 4 を入力中",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xT2iR",
+                  "name": "typingCardBody",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 16,
+                  "padding": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Y3BoB",
+                      "name": "engSentenceList",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "5olAx",
+                          "name": "eng1-completed",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "jY1Jl",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Japan's four seasons each have their own unique beauty and cultural significance.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "oQ2LF",
+                          "name": "eng2-active",
+                          "width": "fill_container",
+                          "fill": "$--accent",
+                          "cornerRadius": 6,
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ysInG",
+                              "fill": "$--foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "In spring, cherry blossoms bloom and many people enjoy hanami.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dtgbv",
+                          "name": "eng3-upcoming",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "AKOkn",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Summer is lively with festivals and fireworks, and in autumn, the autumn leaves color the mountains.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "6KtCu",
+                          "name": "eng4-upcoming",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            16
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "IP7xH",
+                              "fill": "$--muted-foreground",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Winter, despite its tranquility, offers warm pleasures such as hot springs and hot pot dishes.",
+                              "lineHeight": 1.6,
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "Z1HN3",
+                      "type": "ref",
+                      "ref": "bvrBh",
+                      "name": "sentenceInput",
+                      "width": "fill_container",
+                      "x": 24,
+                      "y": 244,
+                      "descendants": {
+                        "reBfl": {
+                          "width": "fill_container",
+                          "height": "fit_content"
+                        },
+                        "mjoFC": {
+                          "width": "fill_container",
+                          "content": "英語を入力"
+                        },
+                        "6t91O": {
+                          "width": "fill_container",
+                          "height": "fit_content"
+                        },
+                        "H6b8U": {
+                          "content": "ここに入力してください"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sgCL5",
+              "name": "statsBar",
+              "width": 960,
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rMfeY",
+                  "name": "s1",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "nzeb3",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "gauge",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dCDPK",
+                      "fill": "$--muted-foreground",
+                      "content": "42 WPM",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xncze",
+                  "name": "s2",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "3SBMx",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "target",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "X5Qeg",
+                      "fill": "$--muted-foreground",
+                      "content": "正確率 94.2%",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pPLz0",
+                  "name": "s3",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ETLzD",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "type",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--muted-foreground"
+                    },
+                    {
+                      "type": "text",
+                      "id": "TplNc",
+                      "fill": "$--muted-foreground",
+                      "content": "28 / 62 文字",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WhXvU",
+                  "name": "s4",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "AzzYB",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "circle-x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$--destructive"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LRt9t",
+                      "fill": "$--muted-foreground",
+                      "content": "ミス 1回",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "JKmN9",
+          "name": "footer",
+          "width": "fill_container",
+          "height": 48,
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$--border"
+          },
+          "padding": [
+            0,
+            32
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "KAvzK",
+              "name": "fLeft",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "TTwcE",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "corner-down-left",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "tQ1lT",
+                  "fill": "$--muted-foreground",
+                  "content": "Enter で次の文へ",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "FRhv0",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "move-horizontal",
+                  "iconFontFamily": "lucide",
+                  "fill": "$--muted-foreground"
+                },
+                {
+                  "type": "text",
+                  "id": "tsyMc",
+                  "fill": "$--muted-foreground",
+                  "content": "Tab でスキップ",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "9BUMo",
+              "fill": "$--muted-foreground",
+              "content": "スペースと大文字小文字も判定対象です。",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "niyvu",
+              "fill": "$--muted-foreground",
+              "content": "中断してホームへ戻る",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- `frontend/docs/typing_app.pen` のデザインファイルを大幅に更新
- UI仕様の拡充（3088行追加）

## Test plan
- [x] Pencilアプリでデザインファイルを開いて表示確認
- [ ] デザイン内容がアプリの要件と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)