### PR TITLE
test: add Alembic migration roundtrip coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,22 @@ jobs:
 
   backend-ci:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://typing_app:typing_app_password@127.0.0.1:5432/typing_app
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: typing_app
+          POSTGRES_PASSWORD: typing_app_password
+          POSTGRES_DB: typing_app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U typing_app"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,14 @@ jobs:
   backend-ci:
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: postgresql://typing_app:typing_app_password@127.0.0.1:5432/typing_app
+      DATABASE_URL: postgresql://typing_app@127.0.0.1:5432/typing_app
     services:
       postgres:
         image: postgres:16-alpine
         env:
           POSTGRES_USER: typing_app
-          POSTGRES_PASSWORD: typing_app_password
           POSTGRES_DB: typing_app
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -36,6 +36,18 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
+    existing_connection = config.attributes.get("connection")
+    if existing_connection is not None:
+        context.configure(
+            connection=existing_connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()  # テストから渡された接続を使って migration を適用する
+        return
+
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",

--- a/backend/database.py
+++ b/backend/database.py
@@ -29,7 +29,7 @@ def _build_alembic_config(database_url: str) -> Config:
     backend_dir = Path(__file__).resolve().parent
     config = Config(str(backend_dir / "alembic.ini"))
     config.set_main_option("script_location", str(backend_dir / "alembic"))
-    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
     return config
 
 

--- a/backend/infrastructure/sqlmodel/tests/test_migrations.py
+++ b/backend/infrastructure/sqlmodel/tests/test_migrations.py
@@ -26,7 +26,7 @@ def _build_alembic_config(database_url: str) -> Config:
     backend_dir = Path(__file__).resolve().parents[3]
     config = Config(str(backend_dir / "alembic.ini"))
     config.set_main_option("script_location", str(backend_dir / "alembic"))
-    config.set_main_option("sqlalchemy.url", database_url)
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
     return config
 
 
@@ -37,6 +37,17 @@ def _build_schema_scoped_url(database_url: str, schema_name: str) -> str:
     merged_options = f"{existing_options} {search_path_option}" if existing_options else search_path_option
     scoped_url: URL = url.update_query_dict({"options": merged_options})
     return str(scoped_url)
+
+
+def test_build_alembic_config_accepts_percent_encoded_database_url() -> None:
+    database_url = (
+        "postgresql://typing_app:typing_app_password@127.0.0.1:5432/typing_app"
+        "?options=-csearch_path%3Dtest_migrations_schema"
+    )
+
+    config = _build_alembic_config(database_url)
+
+    assert config.get_main_option("sqlalchemy.url") == database_url
 
 
 @pytest.fixture

--- a/backend/infrastructure/sqlmodel/tests/test_migrations.py
+++ b/backend/infrastructure/sqlmodel/tests/test_migrations.py
@@ -6,28 +6,24 @@ from uuid import uuid4
 
 import pytest
 from alembic import command
-from alembic.config import Config
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.pool import NullPool
 
-from backend.database import get_database_url
+from backend.database import _build_alembic_config, get_database_url
 
 
-EXPECTED_TABLES = {
+EXPECTED_UPGRADED_TABLES = {
+    "alembic_version",
     "study_results",
     "tags",
     "typing_question_tags",
     "typing_questions",
 }
 
-
-def _build_alembic_config(database_url: str) -> Config:
-    backend_dir = Path(__file__).resolve().parents[3]
-    config = Config(str(backend_dir / "alembic.ini"))
-    config.set_main_option("script_location", str(backend_dir / "alembic"))
-    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
-    return config
+EXPECTED_DOWNGRADED_TABLES = {
+    "alembic_version",
+}
 
 
 def _build_isolated_database_url(database_url: str, database_name: str) -> str:
@@ -85,7 +81,7 @@ def test_migrations_can_upgrade_and_downgrade_roundtrip(isolated_database: str) 
 
     upgraded_engine = create_engine(database_url, poolclass=NullPool)
     upgraded_inspector = inspect(upgraded_engine)
-    assert EXPECTED_TABLES.issubset(set(upgraded_inspector.get_table_names()))
+    assert set(upgraded_inspector.get_table_names()) == EXPECTED_UPGRADED_TABLES
     upgraded_engine.dispose()
 
     with migration_engine.connect() as connection:
@@ -94,7 +90,6 @@ def test_migrations_can_upgrade_and_downgrade_roundtrip(isolated_database: str) 
 
     downgraded_engine = create_engine(database_url, poolclass=NullPool)
     downgraded_inspector = inspect(downgraded_engine)
-    remaining_tables = set(downgraded_inspector.get_table_names())
-    assert EXPECTED_TABLES.isdisjoint(remaining_tables)
+    assert set(downgraded_inspector.get_table_names()) == EXPECTED_DOWNGRADED_TABLES
     downgraded_engine.dispose()
     migration_engine.dispose()

--- a/backend/infrastructure/sqlmodel/tests/test_migrations.py
+++ b/backend/infrastructure/sqlmodel/tests/test_migrations.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.pool import NullPool
+
+from backend.database import get_database_url
+
+
+EXPECTED_TABLES = {
+    "study_results",
+    "tags",
+    "typing_question_tags",
+    "typing_questions",
+}
+
+
+def _build_alembic_config(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+def _build_schema_scoped_url(database_url: str, schema_name: str) -> str:
+    url = make_url(database_url)
+    existing_options = url.query.get("options")
+    search_path_option = f"-csearch_path={schema_name}"
+    merged_options = f"{existing_options} {search_path_option}" if existing_options else search_path_option
+    scoped_url: URL = url.update_query_dict({"options": merged_options})
+    return str(scoped_url)
+
+
+@pytest.fixture
+def isolated_database() -> Iterator[tuple[str, str]]:
+    database_url = get_database_url()
+    schema_name = f"test_migrations_{uuid4().hex}"
+    admin_engine = create_engine(database_url, poolclass=NullPool)
+
+    with admin_engine.begin() as connection:
+        connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))  # 一時 schema を分けて既存テーブル汚染を避ける
+
+    try:
+        yield _build_schema_scoped_url(database_url, schema_name), schema_name
+    finally:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))  # migration 副作用を schema ごと掃除する
+        admin_engine.dispose()
+
+
+def test_migrations_can_upgrade_and_downgrade_roundtrip(isolated_database: tuple[str, str]) -> None:
+    database_url, schema_name = isolated_database
+    config = _build_alembic_config(database_url)
+
+    command.upgrade(config, "head")
+
+    upgraded_engine = create_engine(database_url, poolclass=NullPool)
+    upgraded_inspector = inspect(upgraded_engine)
+    assert EXPECTED_TABLES.issubset(set(upgraded_inspector.get_table_names(schema=schema_name)))
+    upgraded_engine.dispose()
+
+    command.downgrade(config, "base")
+
+    downgraded_engine = create_engine(database_url, poolclass=NullPool)
+    downgraded_inspector = inspect(downgraded_engine)
+    remaining_tables = set(downgraded_inspector.get_table_names(schema=schema_name))
+    assert EXPECTED_TABLES.isdisjoint(remaining_tables)
+    downgraded_engine.dispose()

--- a/backend/infrastructure/sqlmodel/tests/test_migrations.py
+++ b/backend/infrastructure/sqlmodel/tests/test_migrations.py
@@ -30,13 +30,10 @@ def _build_alembic_config(database_url: str) -> Config:
     return config
 
 
-def _build_schema_scoped_url(database_url: str, schema_name: str) -> str:
+def _build_isolated_database_url(database_url: str, database_name: str) -> str:
     url = make_url(database_url)
-    existing_options = url.query.get("options")
-    search_path_option = f"-csearch_path={schema_name}"
-    merged_options = f"{existing_options} {search_path_option}" if existing_options else search_path_option
-    scoped_url: URL = url.update_query_dict({"options": merged_options})
-    return str(scoped_url)
+    isolated_url: URL = url.set(database=database_name, query={})
+    return isolated_url.render_as_string(hide_password=False)
 
 
 def test_build_alembic_config_accepts_percent_encoded_database_url() -> None:
@@ -51,37 +48,53 @@ def test_build_alembic_config_accepts_percent_encoded_database_url() -> None:
 
 
 @pytest.fixture
-def isolated_database() -> Iterator[tuple[str, str]]:
-    database_url = get_database_url()
-    schema_name = f"test_migrations_{uuid4().hex}"
-    admin_engine = create_engine(database_url, poolclass=NullPool)
+def isolated_database() -> Iterator[str]:
+    admin_database_url = get_database_url()
+    database_name = f"test_migrations_{uuid4().hex}"
+    admin_engine = create_engine(admin_database_url, poolclass=NullPool, isolation_level="AUTOCOMMIT")
 
-    with admin_engine.begin() as connection:
-        connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))  # 一時 schema を分けて既存テーブル汚染を避ける
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))  # 一時 database を作り migration 対象を完全分離する
 
     try:
-        yield _build_schema_scoped_url(database_url, schema_name), schema_name
+        yield _build_isolated_database_url(admin_database_url, database_name)
     finally:
-        with admin_engine.begin() as connection:
-            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))  # migration 副作用を schema ごと掃除する
+        with admin_engine.connect() as connection:
+            connection.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )  # Alembic が掴んだ接続を落としてから database を削除する
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
         admin_engine.dispose()
 
 
-def test_migrations_can_upgrade_and_downgrade_roundtrip(isolated_database: tuple[str, str]) -> None:
-    database_url, schema_name = isolated_database
+def test_migrations_can_upgrade_and_downgrade_roundtrip(isolated_database: str) -> None:
+    database_url = isolated_database
     config = _build_alembic_config(database_url)
+    migration_engine = create_engine(database_url, poolclass=NullPool)
 
-    command.upgrade(config, "head")
+    with migration_engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, "head")
 
     upgraded_engine = create_engine(database_url, poolclass=NullPool)
     upgraded_inspector = inspect(upgraded_engine)
-    assert EXPECTED_TABLES.issubset(set(upgraded_inspector.get_table_names(schema=schema_name)))
+    assert EXPECTED_TABLES.issubset(set(upgraded_inspector.get_table_names()))
     upgraded_engine.dispose()
 
-    command.downgrade(config, "base")
+    with migration_engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, "base")
 
     downgraded_engine = create_engine(database_url, poolclass=NullPool)
     downgraded_inspector = inspect(downgraded_engine)
-    remaining_tables = set(downgraded_inspector.get_table_names(schema=schema_name))
+    remaining_tables = set(downgraded_inspector.get_table_names())
     assert EXPECTED_TABLES.isdisjoint(remaining_tables)
     downgraded_engine.dispose()
+    migration_engine.dispose()


### PR DESCRIPTION
## What
- add backend migration roundtrip test that runs `upgrade head -> downgrade base` in an isolated PostgreSQL schema
- verify created tables appear after upgrade and are removed after downgrade
- provision PostgreSQL in GitHub Actions backend CI and set `DATABASE_URL` for migration tests

## Why
- implement #109 so Alembic regressions are caught automatically before future schema work
- keep migration verification isolated from existing local tables by using a temporary schema

## Validation
- `uv run --project backend python -m py_compile backend/infrastructure/sqlmodel/tests/test_migrations.py backend/database.py backend/alembic/env.py`
- `uv run --project backend pytest backend/infrastructure/sqlmodel/tests/test_migrations.py -q` *(fails locally because PostgreSQL on `localhost:5432` was not running in this environment)*
- `docker compose up -d postgres` *(could not be verified here because the local Docker daemon was unavailable)*

## Related
- Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated tests for database migrations to validate schema upgrades and downgrades, ensuring data integrity during deployments.

* **Chores**
  * Enhanced continuous integration environment with database support for improved backend testing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->